### PR TITLE
E-mail address shouldn't be used as secret key

### DIFF
--- a/django_mfa/views.py
+++ b/django_mfa/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from . import totp
 import base64
 import codecs
-    import random
+import random
 from django.contrib.auth.decorators import login_required
 from django_mfa.models import *
 from django.http import HttpResponseRedirect

--- a/django_mfa/views.py
+++ b/django_mfa/views.py
@@ -23,7 +23,8 @@ def configure_mfa(request):
             base_32_secret = base64.b32encode(bytes(request.user.email, 'utf-8'))
         except:
             base_32_secret = base64.b32encode(request.user.email)
-        totp_obj = totp.TOTP(base_32_secret.decode("utf-8"))
+        #IOS Google Authenticator doesn't like the ='s at the end of a secret code
+        totp_obj = totp.TOTP(base_32_secret.decode("utf-8").replace("=",""))
         qr_code = totp_obj.provisioning_uri(request.user.email)
 
     return render(request, 'configure.html', {"qr_code": qr_code, "secret_key": base_32_secret})


### PR DESCRIPTION
Hi,

Using the (b32 encoded) e-mail address as a secret key makes it very easy for anybody to recreate the QR-code, making 2FA more or less useless.

WARNING: this wasn't tested on Python2 as I don't have an installation available.

grts,
Lieven