### PR TITLE
Fix bug with Heroku deploy on bad psycopg2 version

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
 gunicorn==19.6.0
 whitenoise==3.1
 dj-database-url==0.4.1
-psycopg2==2.6.1
+psycopg2==2.7


### PR DESCRIPTION
Heroku deploy wont build due to a bug with psycopg2 2.6 that was fixed in 2.7