### PR TITLE
Remove use of `mark_safe`

### DIFF
--- a/django_mfa/templatetags/otp_tags.py
+++ b/django_mfa/templatetags/otp_tags.py
@@ -4,8 +4,7 @@ except ImportError:
     from urllib import urlencode
 from django import template
 from django.template.defaultfilters import stringfilter
-from django.utils.html import conditional_escape
-from django.utils.safestring import mark_safe
+from django.utils.html import conditional_escape, format_html
 
 register = template.Library()
 
@@ -17,4 +16,4 @@ def qrcode(value, alt=None):
                              urlencode({'chs': '150x150', 'cht': 'qr', 'chl': value, 'choe': 'UTF-8'}))
     alt = conditional_escape(alt or value)
 
-    return mark_safe(u"""<img class="qrcode" src="%s" width="150" height="150" alt="%s" />""" % (url, alt))
+    return format_html(u"""<img class="qrcode" src="%s" width="150" height="150" alt="%s" />""" % (url, alt))


### PR DESCRIPTION
There is a potential risk of XSS attacks when using Django`s `mark_safe`.  This PR aims to remedy that.