### PR TITLE
Update Django version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     install_requires=[
-        "Django>=1.6.0,<=1.11",
+        "Django>=1.6.0,<2.0",
     ],
 )


### PR DESCRIPTION
Include all Django 1.11.*, instead of 1.11 only. Currently we get warning
```
django-mfa 1.0 has requirement Django<=1.11,>=1.6.0, but you'll have django 1.11.15 which is incompatible.
```