### PR TITLE
Make it work with Django 2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Add the following to your root urls.py file.
     urlpatterns = [
         ...
 
-        url(r'^settings/', include('django_mfa.urls', namespace="mfa")),
+        url(r'^settings/', include('django_mfa.urls')),
     ]
 
 

--- a/django_mfa/middleware.py
+++ b/django_mfa/middleware.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import resolve_url
 from django.contrib.auth import REDIRECT_FIELD_NAME as redirect_field_name
 from .models import is_mfa_enabled
@@ -13,7 +13,7 @@ except ImportError:  # Django < 1.10
 class MfaMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
-        if request.user.is_authenticated() and is_mfa_enabled(request.user):
+        if request.user.is_authenticated and is_mfa_enabled(request.user):
             if not request.session.get('verfied_otp'):
                 current_path = request.path
                 if current_path != reverse("mfa:verify_otp"):

--- a/django_mfa/models.py
+++ b/django_mfa/models.py
@@ -9,7 +9,7 @@ class UserOTP(models.Model):
         ('TOTP', 'totp'),
     )
 
-    user = models.OneToOneField(settings.AUTH_USER_MODEL)
+    user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.PROTECT)
     otp_type = models.CharField(max_length=20, choices=OTP_TYPES)
     secret_key = models.CharField(max_length=100, blank=True)
 

--- a/django_mfa/views.py
+++ b/django_mfa/views.py
@@ -5,7 +5,7 @@ import re
 
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django_mfa.models import is_mfa_enabled, UserOTP
@@ -22,17 +22,17 @@ def security_settings(request):
 @login_required
 def configure_mfa(request):
     qr_code = None
-    base_32_secret = None
+    base_32_secret_utf8 = None
     if request.method == "POST":
         base_32_secret = base64.b32encode(
             codecs.decode(codecs.encode(
             '{0:020x}'.format(random.getrandbits(80))
             ), 'hex_codec')
         )
-        totp_obj = totp.TOTP(base_32_secret.decode("utf-8"))
+        base_32_secret_utf8 = base_32_secret.decode("utf-8")
+        totp_obj = totp.TOTP(base_32_secret_utf8)
         qr_code = re.sub(r'=+$', '', totp_obj.provisioning_uri(request.user.email))
-
-    return render(request, 'django_mfa/configure.html', {"qr_code": qr_code, "secret_key": base_32_secret})
+    return render(request, 'django_mfa/configure.html', {"qr_code": qr_code, "secret_key": base_32_secret_utf8})
 
 
 @login_required


### PR DESCRIPTION
The base_32_secret to base_32_secret_utf8 change was required because the secret key appeared in the HTML form as  b'CC5FSNYWXWYVCJKV'  (yes with b'' )
I am guessing that's more likely to do with python version rather than Django.  I am using Python 3.5.2.