### PR TITLE
docs: Fix simple typo, messsages -> messages

### DIFF
--- a/django_mfa/static/django_u2f/u2f-api.js
+++ b/django_mfa/static/django_u2f/u2f-api.js
@@ -37,7 +37,7 @@ var js_api_version;
 
 
 /**
- * Message types for messsages to/from the extension
+ * Message types for messages to/from the extension
  * @const
  * @enum {string}
  */


### PR DESCRIPTION
There is a small typo in django_mfa/static/django_u2f/u2f-api.js.

Should read `messages` rather than `messsages`.

