### PR TITLE
Change max length of recovery code to 16

### DIFF
--- a/django_mfa/migrations/0003_change_secret_code_max_length.py
+++ b/django_mfa/migrations/0003_change_secret_code_max_length.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db import models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_mfa', '0002_auto_20160706_1421'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='UserRecoveryCodes',
+            name='secret_code',
+            field=models.CharField(max_length=16),
+        ),
+    ]

--- a/django_mfa/models.py
+++ b/django_mfa/models.py
@@ -26,7 +26,7 @@ def is_mfa_enabled(user):
 class UserRecoveryCodes(models.Model):
     user = models.ForeignKey(UserOTP,
                              on_delete=models.CASCADE)
-    secret_code = models.CharField(max_length=10)
+    secret_code = models.CharField(max_length=16)
 
 
 class U2FKey(models.Model):


### PR DESCRIPTION
The max_length of UserRecoveryCodes.secret_code field should be 16.

views.generate_user_recovery_codes function tries to save 16-bytes of key on the field in views.py:

```
207 def generate_user_recovery_codes(user_id):
208     no_of_recovery_codes = 10
209     size_of_recovery_code = 16
```