### PR TITLE
Fix and clean up sandbox dependencies

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,13 +1,8 @@
-asn1crypto==0.24.0
-cffi==1.12.2
+cffi==1.14.6
 cryptography==3.3.2
-dj-database-url==0.4.1
-Django==2.1.5
+Django==2.2.19
 django-argonauts==1.2.0
 django-debug-toolbar==1.11
-gunicorn==19.6.0
-pkg-resources==0.0.0
-psycopg2==2.7
 pycparser==2.19
 python-u2flib-server==5.0.0
 pytz==2018.9

--- a/sandbox/test_django_mfa/settings.py
+++ b/sandbox/test_django_mfa/settings.py
@@ -11,7 +11,6 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
-import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -134,11 +133,11 @@ LOGIN_REDIRECT_URL = "/home/"
 
 ALLOWED_HOSTS = ['*']
 
-
 DATABASES = {
-    'default': dj_database_url.config(
-        default='sqlite:////{0}'.format(os.path.join(BASE_DIR, 'db.sqlite3'))
-    )
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
 }
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')


### PR DESCRIPTION
It is impossible to install `requirements.txt` due to conflict between Django versions in `django_mfa` and `sandbox`. This PR fixes the conflict and removes few unnecessary packages from the requirements list.

```
pip install -r requirements.txt 
Collecting Django>=2.2.19
  Using cached Django-3.2.5-py3-none-any.whl (7.9 MB)
Collecting black==20.8b1
  Using cached black-20.8b1-py3-none-any.whl
Collecting asn1crypto==0.24.0
  Using cached asn1crypto-0.24.0-py2.py3-none-any.whl (101 kB)
Collecting cffi==1.12.2
  Using cached cffi-1.12.2.tar.gz (453 kB)
Collecting cryptography==3.3.2
  Using cached cryptography-3.3.2-cp36-abi3-macosx_10_10_x86_64.whl (1.8 MB)
Collecting dj-database-url==0.4.1
  Using cached dj-database-url-0.4.1.tar.gz (4.1 kB)
ERROR: Cannot install Django==2.1.5 and Django>=2.2.19 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested Django>=2.2.19
    The user requested Django==2.1.5

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
```