### PR TITLE
Support for Django 3.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Django-mfa(Multi-factor Authentication) is a simple django package to add extra 
 
 We welcome your feedback on this package. If you run into problems, please raise an issue or contribute to the project by forking the repository and sending some pull requests. 
 
-This Package is compatible with Django versions >=1.10 (including at least Django 2.0.7) Documentation is available at readthedocs(http://django-mfa.readthedocs.io/en/latest/)
+This Package is compatible with the following Django versions: 2.2, 3.0, 3.1, 3.2. Documentation is available at readthedocs(http://django-mfa.readthedocs.io/en/latest/)
 
 Quick start
 -----------

--- a/django_mfa/templates/django_mfa/base.html
+++ b/django_mfa/templates/django_mfa/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load staticfiles %}
+{% load static %}
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/django_mfa/templates/u2f/base.html
+++ b/django_mfa/templates/u2f/base.html
@@ -1,5 +1,5 @@
 {% extends base_template|default:"u2f_base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% block content %}
 <script src="{% static 'django_u2f/u2f-api.js' %}"></script>

--- a/django_mfa/templates/u2f_base.html
+++ b/django_mfa/templates/u2f_base.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-{% load staticfiles %}
 {% load static %}
 <html lang="en" >
   <head>

--- a/docs/installation_setup.rst
+++ b/docs/installation_setup.rst
@@ -5,8 +5,8 @@ Requirements
 ~~~~~~~~~~~~
 
 ======  ====================
-Python  >= 2.6 (or Python 3)
-Django  >= 1.11
+Python  3.6, 3.7, 3.8, 3.9, 3.10
+Django  2.2, 3.0, 3.1, 3.2
 ======  ====================
 
 Installation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Django>=2.2.19
 black==20.8b1
--r sandbox/requirements.txt
+django-argonauts==1.2.0
+python-u2flib-server==5.0.0

--- a/test_runner.py
+++ b/test_runner.py
@@ -22,7 +22,6 @@ if __name__ == "__main__":
             'django.contrib.staticfiles',
             'django_mfa',
             'argonauts',
-            'debug_toolbar',
         ),
         MIDDLEWARE=(
             'django.middleware.security.SecurityMiddleware',
@@ -33,7 +32,6 @@ if __name__ == "__main__":
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
             'django_mfa.middleware.MfaMiddleware',
-            'debug_toolbar.middleware.DebugToolbarMiddleware',
         ),
         ROOT_URLCONF='django_mfa.urls',
         STATIC_URL='/static/',
@@ -52,6 +50,7 @@ if __name__ == "__main__":
                 },
             },
         ],
+        SECRET_KEY='test_secret_key',
     )
 
     django.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{36,37,38,39,310}-django{22,30,31,32}
+
+[testenv]
+deps =
+    -rrequirements.txt
+    django22: Django>=2.2,<2.3
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<3.3
+commands = python test_runner.py


### PR DESCRIPTION
This PR introduces the support for Django 3.0. It also introduces a `tox.ini` config to verify all the supported Python & Django versions.

Closes #56, #64, #35, #37.

Setup & all tests pass on following versions:
- Python >= 3.6, <= 3.10
- Django >= 2.2, < 3.3

Tox output:
```
___________________________________ summary ____________________________________
  py36-django22: commands succeeded
  py36-django30: commands succeeded
  py36-django31: commands succeeded
  py36-django32: commands succeeded
  py37-django22: commands succeeded
  py37-django30: commands succeeded
  py37-django31: commands succeeded
  py37-django32: commands succeeded
  py38-django22: commands succeeded
  py38-django30: commands succeeded
  py38-django31: commands succeeded
  py38-django32: commands succeeded
  py39-django22: commands succeeded
  py39-django30: commands succeeded
  py39-django31: commands succeeded
  py39-django32: commands succeeded
  py310-django22: commands succeeded
  py310-django30: commands succeeded
  py310-django31: commands succeeded
  py310-django32: commands succeeded
```