### PR TITLE
Remove transitive dependency 'sqlparse' from requirements.txt

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -8,5 +8,4 @@ python-u2flib-server==5.0.0
 pytz==2018.9
 qrcode==6.1
 six==1.12.0
-sqlparse==0.3.0
 whitenoise==3.1


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `sqlparse`, which is required by Django, is specified as a requirement in the `requirements.txt` file, even though it is not used directly and does not need to be listed explicitly.

This PR removes it from `requirements.txt` to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!