### PR TITLE
feat: Implement grace period for MFA enrollment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,68 @@ Versions follow [PEP 440](https://peps.python.org/pep-0440/). The version in
 `pyproject.toml` is the only place it is written; the git tag and the GitHub
 Release are derived from it (see [docs/contributing.md](docs/contributing.md)).
 
+## 4.6.0
+
+### Added
+
+- **A rollout ramp for `MFA_REQUIRED`**, for a project turning it on against
+  users who already exist rather than a fresh install. `MFA_REQUIRED_FROM`
+  (a `date`/`datetime` before which nobody is walled by `MFA_REQUIRED`,
+  however it answers) and `MFA_GRACE_PERIOD` (an `int` number of days, or a
+  `timedelta`, each user gets from their own anchor) combine so that a user
+  is required from whichever of `MFA_REQUIRED_FROM` and
+  `anchor + MFA_GRACE_PERIOD` is *later* — an existing account is governed
+  by the announced cutover, while someone who signs up after it still gets
+  their full window. `MFA_GRACE_ANCHOR` supplies a per-user anchor other
+  than `user.date_joined` (a dotted path or callable, `(user) -> datetime |
+  None`) for a clock `date_joined` can't express, such as a migration
+  cohort. `policy.required_at(user)` and `policy.grace_state(user)` (a
+  `GraceState(required_at, days_remaining)`, display-only) are the public
+  entry points. Grace suppresses `MFA_REQUIRED` only — it does not open
+  `@mfa_required`/`MfaRequiredMixin` views, exactly like an `MfaExemption`,
+  and it does **not** open the `MFA_PROTECT_ADMIN` gate either: that gate is
+  enforced through `decorators.enforcement_state()`, which never consults
+  `django_mfa.policy` at all. See [docs/enforcement.md](docs/enforcement.md).
+- **Grace surfaced everywhere the enrollment wall already is**: a `grace`
+  key in `security_settings`'s context, the opt-in
+  `django_mfa.context_processors.mfa` template context processor
+  (`mfa_grace`), the JSON API's `state` endpoint (`grace` field), and
+  `mfa_status`'s new "In grace until" line. `mfa_report` now also lists
+  users currently in grace — see the Changed entry below for its CSV
+  output.
+- **`MFA_PROTECT_ADMIN`** (default `False`). When `True`, no page on the
+  default admin site (`django.contrib.admin.site`) is reachable without a
+  verified session — enforced by `django_mfa.admin_site.protect_admin_site()`
+  wrapping that site's own `has_permission()`/`login()` in place, so it
+  holds even on a project that never installed `MfaMiddleware`. A project
+  mounting its own `AdminSite` instance gets no protection from the setting
+  alone; `django_mfa.admin_site.MfaAdminMixin` covers that case. It also
+  unions `is_staff` into `policy.resolve()`'s predicate, so staff become
+  subject to `MFA_REQUIRED` without a second setting — without rewriting
+  `MFA_REQUIRED` itself. **`MFA_ADMIN_STEPUP`** (default `False`) additionally
+  requires a challenge within `MFA_STEPUP_MAX_AGE`, not merely a verified
+  session, once `MFA_PROTECT_ADMIN` is on. See
+  [docs/enforcement.md](docs/enforcement.md).
+- **System checks `django_mfa.E010`** (grace is configured but cannot
+  apply — `MFA_REQUIRED_FROM` isn't a date, `MFA_GRACE_PERIOD` is negative
+  or not a number, or it's set with no usable anchor) and
+  **`django_mfa.E011`** (`MFA_ADMIN_STEPUP` set without `MFA_PROTECT_ADMIN`,
+  so nothing reads it and the admin stays unprotected).
+- **`decorators.enforcement_redirect(request, require_primary_factor=True,
+  next_url=None)`** is now public — it renders an `enforcement_state()` rung
+  as a redirect, and `django_mfa.admin_site` calls it directly to reuse the
+  same two destinations `MfaMiddleware` and `@mfa_required` already redirect
+  to. The previous private name, `_enforce`, remains as a back-compat alias.
+
+### Changed
+
+- `mfa_report --format csv` gains a `grace_until` column, appended after the
+  existing ones (so indexing by position still works for those). Users
+  inside a grace window are now listed by `mfa_report`; previously — before
+  grace existed — there was no such state.
+
+No new migration — this release adds no models.
+
 ## 4.5.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Django's own `user_logged_in` signal.
 | ➕ **Several keys at once** | A user can register a work laptop's Touch ID *and* a backup YubiKey, each with its own name. |
 | 🌍 **Six languages** | German, Spanish, French, Brazilian Portuguese, Japanese and Simplified Chinese ship translated. Switch on `USE_I18N` and they work. |
 | 🔌 **A JSON API** | Opt-in. Every flow above as JSON, for an SPA or mobile client that renders its own screens. No DRF dependency, and a revocable session token for clients that hold no cookie. |
+| 🛡️ **Admin protection** | `MFA_PROTECT_ADMIN = True`. No page on `django.contrib.admin`'s default site without a verified second factor — enforced by the admin itself, so it holds even without the middleware. A project mounting its own `AdminSite` needs the `MfaAdminMixin` instead. Optionally require a *recent* challenge, not just a verified session. |
 
 ## Install
 

--- a/django_mfa/admin_site.py
+++ b/django_mfa/admin_site.py
@@ -1,0 +1,177 @@
+"""Second-factor protection for the Django admin.
+
+The admin is the single most common reason a project wants MFA at all, and
+the settings-only recipe (MFA_REQUIRED = is_staff, plus MfaMiddleware, plus
+no admin path in MFA_EXEMPT_PATHS) fails SILENTLY if any part is missed.
+This enforces it from inside the admin site, so it holds with no middleware
+installed.
+
+Neither override restates a rule. has_permission() reads
+decorators.enforcement_state(); login() renders it through
+decorators.enforcement_redirect(), which is public for exactly this reason.
+"""
+
+import functools
+
+from django.contrib.auth.views import redirect_to_login
+from django.shortcuts import resolve_url
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import never_cache
+
+from django_mfa import decorators
+from django_mfa.conf import settings as mfa_settings
+
+#: Marks a site instance as already wrapped. Some runners call AppConfig.
+#: ready() more than once, and double-wrapping would evaluate every gate
+#: twice per request.
+_PATCHED = "_django_mfa_protected"
+
+
+def _gates_pass(request):
+    """Does this request clear every MFA gate the admin imposes?
+
+    Deliberately does not re-check MFA_PROTECT_ADMIN here -- once
+    protect_admin_site() has patched a site, the gate stays active for that
+    site's lifetime regardless of what the setting says afterward. Right for
+    production (nothing ever flips this off mid-process), but worth knowing
+    if a test suite patches a site directly and expects toggling the setting
+    alone to unpatch it -- it doesn't; call protect_admin_site() again after
+    removing the patch attributes, or don't patch until the setting is what
+    you want.
+    """
+    if decorators.enforcement_state(request) is not None:
+        return False
+    if (mfa_settings.MFA_ADMIN_STEPUP
+            and decorators.recent_enforcement_state(request) is not None):
+        return False
+    return True
+
+
+def _login_redirect(request):
+    """Where an authenticated-but-ungated admin request goes, or None.
+
+    Only ever acts on an authenticated user. AdminSite.admin_view renders a
+    failed has_permission() as a redirect to admin:login, so without this an
+    already-logged-in staff user is shown a login form -- confusing, and
+    django-two-factor-auth's long-standing wart. An anonymous user is left
+    entirely alone: the admin's own form is the right answer for them, and
+    enforcement_redirect()'s UNAUTHENTICATED branch must not compete with it.
+
+    next_url is the admin index rather than request.get_full_path(), which
+    here is /admin/login/?next=... -- replaying that after verifying is a
+    round trip through a login view the user is already past.
+    """
+    if not request.user.is_authenticated:
+        return None
+
+    next_url = request.GET.get("next") or reverse("admin:index")
+
+    response = decorators.enforcement_redirect(request, next_url=next_url)
+    if response is not None:
+        return response
+
+    # enforcement_state() passed but the step-up rung has not: MFA_ADMIN_STEPUP
+    # is on and the challenge is older than MFA_STEPUP_MAX_AGE. Admin pages
+    # reaching this are GETs, so replaying the path is safe and
+    # _enforce_recent()'s POST carve-out does not apply.
+    if (mfa_settings.MFA_ADMIN_STEPUP
+            and decorators.recent_enforcement_state(request) is not None):
+        return redirect_to_login(
+            next_url, resolve_url(reverse("mfa:verify")), "next")
+
+    return None
+
+
+class MfaAdminMixin:
+    """Mix in front of AdminSite to require a verified session.
+
+    Public for hosts that would rather wire this explicitly than let
+    MFA_PROTECT_ADMIN patch the default site. That route needs an AdminConfig
+    subclass with default_site in INSTALLED_APPS, which is not a one-liner
+    and collides with any other package claiming default_site -- hence the
+    setting being the advertised path.
+    """
+
+    def has_permission(self, request):
+        return super().has_permission(request) and _gates_pass(request)
+
+    @method_decorator(never_cache)
+    def login(self, request, extra_context=None):
+        response = _login_redirect(request)
+        if response is not None:
+            return response
+        return super().login(request, extra_context)
+
+    # AdminSite.login is decorated `@login_not_required` (Django >= 5.1),
+    # which LoginRequiredMiddleware reads off the URL pattern's callable to
+    # decide whether an anonymous request may reach it at all. Overriding
+    # the method here replaces that callable and drops the marker unless it
+    # is restored explicitly -- without this, an anonymous visitor to
+    # admin:login is bounced to LOGIN_URL by that middleware, which is
+    # usually a page that doesn't exist. Setting the attribute directly
+    # (rather than importing login_not_required) keeps this working on
+    # Django 4.2, which has neither the decorator nor anything that reads
+    # the attribute -- the assignment is simply inert there.
+    login.login_required = False
+
+
+def protect_admin_site(site):
+    """Wrap an existing AdminSite instance in place.
+
+    Wraps the bound methods rather than swapping the class, so this composes
+    with a host project's own AdminSite subclass instead of replacing it --
+    and so there is no zero-argument super() to break when a function is
+    bound to an instance after class creation.
+
+    Timing is two different stories for the two methods this patches, and
+    only one of them is forgiving:
+
+    - has_permission is read fresh on every request -- AdminSite.get_urls()
+      wraps most views in a closure that calls ``self.has_permission(request)``
+      at call time, not at get_urls() time -- so patching it is safe
+      regardless of when get_urls() first runs relative to this call.
+    - login is NOT read fresh. AdminSite.get_urls() wires the `login/` URL
+      directly to ``self.login`` (unlike every other view, it is not passed
+      through that closure), so whatever ``self.login`` resolves to AT THE
+      MOMENT get_urls() first runs is what every future request to
+      admin:login gets, forever -- get_urls() only ever runs once, the
+      first time admin.site.urls is accessed, and Python caches the
+      importing module so nothing re-evaluates it later. This function
+      MUST therefore run before the URLconf module that mounts admin.site.urls
+      is first imported. Calling it from AppConfig.ready() satisfies that in
+      a normal deployment, since URL resolution is lazy and does not happen
+      until the first real request, well after django.setup() (and every
+      app's ready()) has completed.
+    """
+    if getattr(site, _PATCHED, False):
+        return
+
+    original_has_permission = site.has_permission
+    original_login = site.login
+
+    def has_permission(request):
+        return original_has_permission(request) and _gates_pass(request)
+
+    @never_cache
+    def login(request, extra_context=None):
+        response = _login_redirect(request)
+        if response is not None:
+            return response
+        return original_login(request, extra_context)
+
+    # original_login is AdminSite.login, decorated `@login_not_required`
+    # (Django >= 5.1) so LoginRequiredMiddleware lets an anonymous visitor
+    # reach it at all -- that decorator just sets login_required = False in
+    # the function's __dict__. update_wrapper copies __dict__, so this
+    # carries the marker (and anything else a host's own AdminSite subclass
+    # set) onto the replacement without this module needing to import
+    # login_not_required itself, which does not exist before Django 5.1 and
+    # would break the Django 4.2 floor. Applied after @never_cache so the
+    # final object -- what site.login actually becomes -- is the one that
+    # gets the copy, not an intermediate.
+    functools.update_wrapper(login, original_login)
+
+    site.has_permission = has_permission
+    site.login = login
+    setattr(site, _PATCHED, True)

--- a/django_mfa/api/views.py
+++ b/django_mfa/api/views.py
@@ -42,7 +42,7 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_protect
 
-from django_mfa import decorators, events, flows, session
+from django_mfa import decorators, events, flows, policy, session
 from django_mfa.adapters.recovery_codes import RecoveryCodesAdapter
 from django_mfa.api import auth, tokens
 from django_mfa.conf import settings as mfa_settings
@@ -251,6 +251,29 @@ def serialize_adapter(adapter):
             "supports_multiple": adapter.supports_multiple}
 
 
+def serialize_grace(user):
+    """policy.GraceState as JSON, or None.
+
+    Reachable while pending (state always is), so a client can draw the
+    "you have N days" banner before the user has verified anything.
+
+    ``required_at`` is passed through as a datetime rather than
+    ``.isoformat()``'d here, so JsonResponse's DjangoJSONEncoder renders it
+    the same way it renders every other datetime in this response (e.g.
+    ``created_at`` in serialize_authenticator) -- "2026-08-14T09:12:03.114Z",
+    not isoformat()'s "2026-08-14T09:12:03.114000+00:00". A second encoding
+    of the same kind of value in the same response is a bug waiting for a
+    client that only handles one of them.
+    """
+    grace = policy.grace_state(user)
+    if grace is None:
+        return None
+    return {
+        "required_at": grace.required_at,
+        "days_remaining": grace.days_remaining,
+    }
+
+
 @endpoint("GET", require_verified=False)
 def state(request):
     """Everything a client needs to render the right screen.
@@ -277,6 +300,7 @@ def state(request):
         "recovery_codes_remaining":
             RecoveryCodesAdapter().remaining(request.user),
         "stepup_max_age": mfa_settings.MFA_STEPUP_MAX_AGE,
+        "grace": serialize_grace(request.user),
     })
 
 

--- a/django_mfa/apps.py
+++ b/django_mfa/apps.py
@@ -9,8 +9,10 @@ class DjangoMfaAppConfig(AppConfig):
 
     def ready(self):
         from django_mfa.checks import (
+            check_admin_stepup,
             check_client_ip_resolver,
             check_fido2_rp_id,
+            check_grace_configuration,
             check_mfa_api_authentication,
             check_mfa_required_predicate,
             check_rate_limit_backend,
@@ -27,9 +29,24 @@ class DjangoMfaAppConfig(AppConfig):
         register(check_rate_limit_specs)
         register(check_rate_limit_backend)
         register(check_client_ip_resolver)
+        register(check_grace_configuration)
+        register(check_admin_stepup)
+
+        from django.apps import apps as django_apps
 
         from django_mfa import (
             adapters,  # noqa: F401  (registers built-ins)
             notifications,  # noqa: F401  (connects notification receivers)
             signals,  # noqa: F401
         )
+        from django_mfa.conf import settings as mfa_settings
+
+        # No-op without django.contrib.admin: a project with no admin that
+        # sets MFA_PROTECT_ADMIN is odd but must not crash at startup.
+        if (mfa_settings.MFA_PROTECT_ADMIN
+                and django_apps.is_installed("django.contrib.admin")):
+            from django.contrib import admin
+
+            from django_mfa.admin_site import protect_admin_site
+
+            protect_admin_site(admin.site)

--- a/django_mfa/checks.py
+++ b/django_mfa/checks.py
@@ -308,3 +308,140 @@ def check_client_ip_resolver(app_configs, **kwargs):
             id="django_mfa.E009",
         )]
     return []
+
+
+def check_grace_configuration(app_configs, **kwargs):
+    """Grace that is configured but cannot possibly work.
+
+    Every case here fails by silently granting NO grace, which is the worst
+    failure mode this feature has: the operator believes they shipped a ramp
+    and in fact shipped a wall, and they find out from their users. Gated so
+    an install with neither setting evaluates nothing.
+
+    MFA_GRACE_ANCHOR is validated the same way MFA_REQUIRED/E004,
+    MFA_API_AUTHENTICATION/E006 and MFA_CLIENT_IP_RESOLVER/E009 already are:
+    imported here (if it's a string) and asserted callable, rather than left
+    to fail at request time. Without this, a typo'd dotted path is not
+    caught until policy._anchor() imports and calls it inside
+    required_at() -> mfa_required_for() -> MfaMiddleware, i.e. a 500 raised
+    from middleware on the first request from any user MFA_REQUIRED matches.
+
+    MFA_GRACE_ANCHOR set without MFA_GRACE_PERIOD is the same failure class
+    as MFA_ADMIN_STEPUP without MFA_PROTECT_ADMIN (E011): required_at() only
+    ever calls _anchor() when _period() is not None, so the anchor is
+    silently never consulted.
+    """
+    import datetime
+
+    from django.contrib.auth import get_user_model
+
+    errors = []
+
+    cutover = mfa_settings.MFA_REQUIRED_FROM
+    if cutover is not None and not isinstance(cutover, datetime.date):
+        # datetime is a subclass of date, so this accepts both.
+        errors.append(Error(
+            f"MFA_REQUIRED_FROM must be a date or datetime, got "
+            f"{type(cutover).__name__}.",
+            hint="A string is not parsed. Use datetime.date(2026, 9, 1).",
+            id="django_mfa.E010",
+        ))
+
+    anchor_setting = mfa_settings.MFA_GRACE_ANCHOR
+    if anchor_setting is not None:
+        anchor = anchor_setting
+        if isinstance(anchor, str):
+            try:
+                anchor = import_string(anchor)
+            except ImportError as exc:
+                errors.append(Error(
+                    f"MFA_GRACE_ANCHOR is not importable: {exc}",
+                    hint="Set it to a dotted path to a callable taking a "
+                         "user and returning a datetime or None, or leave "
+                         "it unset to use user.date_joined.",
+                    id="django_mfa.E010",
+                ))
+                anchor = None
+        if anchor is not None and not callable(anchor):
+            errors.append(Error(
+                f"MFA_GRACE_ANCHOR must be a callable, or a dotted path to "
+                f"one -- got {anchor_setting!r}.",
+                hint="It takes a user and returns the datetime their "
+                     "personal grace window starts from, or None to fall "
+                     "back to MFA_REQUIRED_FROM alone.",
+                id="django_mfa.E010",
+            ))
+        if mfa_settings.MFA_GRACE_PERIOD is None:
+            errors.append(Error(
+                "MFA_GRACE_ANCHOR is set but MFA_GRACE_PERIOD is not.",
+                hint="Nothing reads MFA_GRACE_ANCHOR unless MFA_GRACE_PERIOD "
+                     "is also set -- required_at() only consults the anchor "
+                     "for a per-user window, and there is none without a "
+                     "period. Set MFA_GRACE_PERIOD.",
+                id="django_mfa.E010",
+            ))
+
+    period = mfa_settings.MFA_GRACE_PERIOD
+    if period is not None:
+        if isinstance(period, datetime.timedelta):
+            negative = period < datetime.timedelta(0)
+        else:
+            try:
+                negative = period < 0
+            except TypeError:
+                # A non-numeric, non-timedelta value (e.g. "14" instead of
+                # 14) would otherwise raise a bare TypeError out of this
+                # check instead of being reported like every other bad
+                # setting here. Nothing left to check against an unusable
+                # value, so skip the negative/anchor checks below.
+                errors.append(Error(
+                    f"MFA_GRACE_PERIOD must be a number of days, a "
+                    f"datetime.timedelta, or None, got {period!r}.",
+                    hint="Use an int or float number of days, a "
+                         "datetime.timedelta, or None to switch the "
+                         "per-user window off.",
+                    id="django_mfa.E010",
+                ))
+                negative = False
+                period = None
+        if negative:
+            errors.append(Error(
+                "MFA_GRACE_PERIOD is negative.",
+                hint="A negative window is already expired for every user, "
+                     "which grants no grace at all. Use a positive number of "
+                     "days, or None to switch the per-user window off.",
+                id="django_mfa.E010",
+            ))
+        elif period is not None and (
+                mfa_settings.MFA_GRACE_ANCHOR is None
+                and not hasattr(get_user_model(), "date_joined")):
+            errors.append(Error(
+                "MFA_GRACE_PERIOD is set but AUTH_USER_MODEL has no "
+                "date_joined field and MFA_GRACE_ANCHOR is unset.",
+                hint="The per-user window has no clock to start from, so no "
+                     "user will receive one. Set MFA_GRACE_ANCHOR to a "
+                     "callable (or dotted path) returning the datetime each "
+                     "user's window starts from.",
+                id="django_mfa.E010",
+            ))
+
+    return errors
+
+
+def check_admin_stepup(app_configs, **kwargs):
+    """MFA_ADMIN_STEPUP without MFA_PROTECT_ADMIN does nothing at all.
+
+    Nothing reads MFA_ADMIN_STEPUP unless the admin site has been wrapped,
+    and only MFA_PROTECT_ADMIN wraps it. An operator setting the stronger
+    of the two alone believes the admin is step-up protected and it is not
+    protected at all.
+    """
+    if mfa_settings.MFA_ADMIN_STEPUP and not mfa_settings.MFA_PROTECT_ADMIN:
+        return [Error(
+            "MFA_ADMIN_STEPUP is set but MFA_PROTECT_ADMIN is not.",
+            hint="Nothing reads MFA_ADMIN_STEPUP unless MFA_PROTECT_ADMIN "
+                 "has wrapped the admin site, so the admin is currently "
+                 "unprotected. Set MFA_PROTECT_ADMIN = True.",
+            id="django_mfa.E011",
+        )]
+    return []

--- a/django_mfa/conf.py
+++ b/django_mfa/conf.py
@@ -16,6 +16,9 @@ DEFAULTS = {
     "MFA_OWNED_BY_ENTERPRISE": False,
     "MFA_FACTORS": ["totp", "recovery_codes", "webauthn"],
     "MFA_REQUIRED": False,
+    "MFA_REQUIRED_FROM": None,
+    "MFA_GRACE_PERIOD": None,
+    "MFA_GRACE_ANCHOR": None,
     "MFA_FIDO2_RP_ID": None,
     "MFA_FIDO2_RP_NAME": "django-mfa",
     "MFA_FIDO2_RESIDENT_KEY": "preferred",
@@ -30,6 +33,8 @@ DEFAULTS = {
     "MFA_FROM_EMAIL": None,
     "MFA_NOTIFY_ON_CHANGE": False,
     "MFA_API_AUTHENTICATION": None,
+    "MFA_PROTECT_ADMIN": False,
+    "MFA_ADMIN_STEPUP": False,
 }
 
 

--- a/django_mfa/context_processors.py
+++ b/django_mfa/context_processors.py
@@ -1,0 +1,31 @@
+"""Grace state for a host project's own chrome.
+
+This package renders no site-wide banner itself -- it does not own the
+host's base template -- so the one thing it can usefully offer is the state,
+site-wide, for the host to render however it likes.
+
+Opt-in: add "django_mfa.context_processors.mfa" to TEMPLATES.
+"""
+
+from django.utils.functional import SimpleLazyObject
+
+from django_mfa import policy
+
+
+def mfa(request):
+    """Expose ``mfa_grace`` to every template.
+
+    Lazy for the same reason django.contrib.auth's own context processor is
+    lazy about `user`/`perms`: this runs on every template render, and
+    policy.grace_state() resolves the MFA_REQUIRED predicate --
+    policy.in_groups(...) is a query. A template that never mentions
+    mfa_grace must not pay for it.
+    """
+    user = getattr(request, "user", None)
+
+    def resolve():
+        if user is None or not user.is_authenticated:
+            return None
+        return policy.grace_state(user)
+
+    return {"mfa_grace": SimpleLazyObject(resolve)}

--- a/django_mfa/decorators.py
+++ b/django_mfa/decorators.py
@@ -103,16 +103,32 @@ def enforcement_state(request, require_primary_factor=True):
     return None
 
 
-def _enforce(request, require_primary_factor=True):
-    """Render enforcement_state() as a redirect, or None to let it through."""
+def enforcement_redirect(request, require_primary_factor=True, next_url=None):
+    """Render enforcement_state() as a redirect, or None to let it through.
+
+    Public because django_mfa.admin_site needs exactly this mapping.
+    Copying it there would be a second copy of the thing flows.py and
+    api/views.py's GATES table exist to prevent -- rung names in one place,
+    renderings in as many places as there are response formats.
+
+    next_url overrides where the user is sent back to after verifying. The
+    admin needs it: a failed admin gate arrives here on /admin/login/, and
+    replaying THAT path afterwards is a pointless round trip through a login
+    view the user is already past.
+    """
     state = enforcement_state(request, require_primary_factor)
     if state is None:
         return None
+    target = next_url or request.get_full_path()
     if state == UNAUTHENTICATED:
-        return redirect_to_login(request.get_full_path())
-    target = ("mfa:verify" if state == PENDING else "mfa:security_settings")
-    return redirect_to_login(request.get_full_path(),
-                             resolve_url(reverse(target)), "next")
+        return redirect_to_login(target)
+    destination = "mfa:verify" if state == PENDING else "mfa:security_settings"
+    return redirect_to_login(target, resolve_url(reverse(destination)), "next")
+
+
+def _enforce(request, require_primary_factor=True):
+    """Back-compat alias. Every existing call site goes through this."""
+    return enforcement_redirect(request, require_primary_factor)
 
 
 def mfa_required(view_func):

--- a/django_mfa/management/commands/mfa_report.py
+++ b/django_mfa/management/commands/mfa_report.py
@@ -42,20 +42,50 @@ class Command(BaseCommand):
         # callable. has_primary_factor() first: it is the cheaper of the two
         # and excludes most users before the predicate (and its exemption
         # lookup) runs at all.
-        outstanding = [
-            user for user in model.objects.all().iterator()
-            if not registry.has_primary_factor(user)
-            and policy.mfa_required_for(user)
-        ]
+        #
+        # `or grace_state(...)` is load-bearing, not belt-and-braces:
+        # mfa_required_for() returns False during the grace window, so
+        # filtering on it alone would silently drop every user still inside
+        # their window -- exactly the people a rollout needs to watch.
+        # grace_state() returns non-None only for a user who WOULD be walled
+        # but is not yet, so the pair is precisely "owes us a factor, now or
+        # soon".
+        #
+        # grace_state() is computed AT MOST ONCE per user, here, and carried
+        # through as (user, grace) pairs rather than recomputed in the CSV
+        # and text loops below -- both mfa_required_for() and grace_state()
+        # pay for the predicate and (on grace_state()'s side) an
+        # has_active_exemption() query, and this command iterates the whole
+        # user table. For a past-due user mfa_required_for() short-circuits
+        # the `or`, so grace_state() is never called at all for them -- only
+        # an in-grace user pays for it, and only once.
+        outstanding = []
+        for user in model.objects.all().iterator():
+            if registry.has_primary_factor(user):
+                continue
+            if policy.mfa_required_for(user):
+                outstanding.append((user, None))
+                continue
+            grace = policy.grace_state(user)
+            if grace is not None:
+                outstanding.append((user, grace))
 
         if options["format"] == "csv":
             writer = csv.writer(self.stdout)
-            writer.writerow(["pk", field])
-            for user in outstanding:
-                writer.writerow([user.pk, getattr(user, field)])
+            # grace_until is APPENDED, never inserted: a consumer indexing
+            # by column position keeps working for the columns it knew about.
+            writer.writerow(["pk", field, "grace_until"])
+            for user, grace in outstanding:
+                writer.writerow([
+                    user.pk,
+                    getattr(user, field),
+                    grace.required_at.isoformat() if grace else "",
+                ])
             return
 
         self.stdout.write(
             f"Required but unenrolled: {len(outstanding)}")
-        for user in outstanding:
-            self.stdout.write(f"  - {getattr(user, field)} (pk={user.pk})")
+        for user, grace in outstanding:
+            suffix = (f" -- in grace until {grace.required_at:%Y-%m-%d}"
+                      if grace else "")
+            self.stdout.write(f"  - {getattr(user, field)} (pk={user.pk}){suffix}")

--- a/django_mfa/management/commands/mfa_status.py
+++ b/django_mfa/management/commands/mfa_status.py
@@ -47,6 +47,12 @@ class Command(BaseCommand):
         required = policy.mfa_required_for(user)
         self.stdout.write(f"Required: {'yes' if required else 'no'}")
 
+        grace = policy.grace_state(user)
+        if grace is not None:
+            self.stdout.write(
+                f"In grace until {grace.required_at:%Y-%m-%d} "
+                f"({grace.days_remaining} days)")
+
         exemption = MfaExemption.objects.active_for(user)
 
         if exemption is not None:

--- a/django_mfa/policy.py
+++ b/django_mfa/policy.py
@@ -16,9 +16,14 @@ actually have it is registry.primary_enabled_for(user), which stays the
 single source of truth for that -- do not add a second definition here.
 """
 
+import datetime
+import math
+from dataclasses import dataclass
 from functools import cache
 
+from django.conf import settings as django_settings
 from django.core.exceptions import ImproperlyConfigured
+from django.utils import timezone
 from django.utils.module_loading import import_string
 
 from django_mfa.conf import settings as mfa_settings
@@ -56,7 +61,20 @@ def _import(path):
 
 
 def resolve():
-    """Return ``MFA_REQUIRED`` as a callable predicate, or None when off.
+    """Return the effective policy as a callable predicate, or None when off.
+
+    Starts from ``MFA_REQUIRED`` and, when ``MFA_PROTECT_ADMIN`` is on,
+    unions in ``is_staff`` -- so a staff user must hold a factor even for an
+    install that never sets MFA_REQUIRED at all. MFA_PROTECT_ADMIN does NOT
+    write to or override MFA_REQUIRED; the union happens only here, so this
+    stays the single function answering "who must hold a factor" and
+    mfa_status, mfa_report and both MfaMiddleware rungs stay truthful with no
+    changes of their own.
+
+    The union is built FRESH on every call. ``_import()`` is @cache'd on the
+    dotted path string (deliberately, so override_settings() is honoured);
+    caching the composed predicate alongside it would pin a test that
+    toggles MFA_PROTECT_ADMIN to whatever was resolved first.
 
     Raises ImproperlyConfigured (or ImportError, from _import) for a value it
     cannot use. Both are caught at startup by checks.check_mfa_required_
@@ -65,17 +83,31 @@ def resolve():
     """
     value = mfa_settings.MFA_REQUIRED
     if value is None or value is False:
-        return None
-    if value is True:
-        return lambda user: True
-    if isinstance(value, str):
-        value = _import(value)
-    if not callable(value):
-        raise ImproperlyConfigured(
-            f"MFA_REQUIRED must be a bool, a callable, or a dotted path to "
-            f"one -- got {value!r}."
-        )
-    return value
+        predicate = None
+    elif value is True:
+        def predicate(user):
+            return True
+    else:
+        if isinstance(value, str):
+            value = _import(value)
+        if not callable(value):
+            raise ImproperlyConfigured(
+                f"MFA_REQUIRED must be a bool, a callable, or a dotted path "
+                f"to one -- got {value!r}."
+            )
+        predicate = value
+
+    if not mfa_settings.MFA_PROTECT_ADMIN:
+        return predicate
+    if predicate is None:
+        return is_staff
+
+    base = predicate
+
+    def required_or_staff(user):
+        return base(user) or is_staff(user)
+
+    return required_or_staff
 
 
 def has_active_exemption(user):
@@ -85,12 +117,37 @@ def has_active_exemption(user):
     return MfaExemption.objects.active_for(user) is not None
 
 
-def mfa_required_for(user):
-    """Is this user required to hold a primary second factor?"""
+def _predicate_matches(user):
+    """Does MFA_REQUIRED's predicate select this user at all?
+
+    The half mfa_required_for() and _applies() genuinely share. Split out
+    rather than duplicated: the two differ only in what they check AFTER
+    this, and a security predicate copied into two places is one that will
+    be fixed in one place.
+    """
     if not getattr(user, "is_authenticated", False):
         return False
     predicate = resolve()
-    if not (predicate and predicate(user)):
+    return bool(predicate and predicate(user))
+
+
+def mfa_required_for(user):
+    """Is this user required to hold a primary second factor?"""
+    if not _predicate_matches(user):
+        return False
+    # Grace before the exemption lookup, on purpose. At this point the
+    # predicate is already paid for, MFA_REQUIRED_FROM is a setting and
+    # date_joined is already on the loaded user object -- so this clause is
+    # free, and an in-grace user short-circuits before
+    # has_active_exemption()'s SELECT ... LIMIT 1 and costs LESS than the
+    # same user does today.
+    #
+    # This suppresses MFA_REQUIRED only. It does not open @mfa_required
+    # views: decorators.enforcement_state() does not consult policy at all,
+    # which is deliberate and is pinned by
+    # test_decorators.GraceDoesNotOpenDecoratedViewsTests.
+    due = required_at(user)
+    if due is not None and timezone.now() < due:
         return False
     # Checked last, on purpose: an install with the default
     # MFA_REQUIRED = False never reaches the database for this, and one with
@@ -101,3 +158,137 @@ def mfa_required_for(user):
     # not just yes/no, and there is no reason for the two to run separate
     # queries for the same answer.
     return not has_active_exemption(user)
+
+
+@dataclass(frozen=True)
+class GraceState:
+    """A user who *would* be walled, but is not yet.
+
+    ``days_remaining`` is rounded UP and is for display only -- nothing
+    enforces against it. Rounding down would render "0 days left" for a
+    window with twenty-three hours still in it, which reads as "expired" to
+    the very user it is trying to warn. Enforcement always compares
+    timezone.now() against required_at directly.
+    """
+
+    required_at: datetime.datetime
+    days_remaining: int
+
+
+def _match_tz(value):
+    """Put a datetime into whichever awareness USE_TZ implies.
+
+    Mixed awareness raises TypeError on comparison, and both halves of this
+    feature compare user-supplied datetimes (a setting, an anchor) against
+    timezone.now(). Follows MfaExemption.__str__'s precedent: convert only
+    when there is something to convert, so USE_TZ = False does not raise.
+    """
+    if value is None:
+        return None
+    if django_settings.USE_TZ and timezone.is_naive(value):
+        return timezone.make_aware(value)
+    if not django_settings.USE_TZ and timezone.is_aware(value):
+        return timezone.make_naive(value)
+    return value
+
+
+def _as_datetime(value):
+    """MFA_REQUIRED_FROM as a comparable datetime. A bare date means midnight."""
+    if value is None:
+        return None
+    if isinstance(value, datetime.datetime):
+        return _match_tz(value)
+    if isinstance(value, datetime.date):
+        return _match_tz(datetime.datetime.combine(value, datetime.time.min))
+    raise ImproperlyConfigured(
+        f"MFA_REQUIRED_FROM must be a date or datetime -- got {value!r}.")
+
+
+def _period():
+    """MFA_GRACE_PERIOD as a timedelta, or None."""
+    value = mfa_settings.MFA_GRACE_PERIOD
+    if value is None:
+        return None
+    if isinstance(value, datetime.timedelta):
+        return value
+    return datetime.timedelta(days=value)
+
+
+def _anchor(user):
+    """Where this user's personal grace window starts, or None for 'no window'.
+
+    getattr rather than user.date_joined: AUTH_USER_MODEL is swappable and a
+    host project's user model need not have that field at all. A custom
+    resolver returning None means the same thing -- it legitimately has
+    nothing to say about some users -- and is documented behaviour, not an
+    error. check_grace_configuration (django_mfa.E010) covers only the case
+    where an anchor could never resolve for anyone.
+    """
+    resolver = mfa_settings.MFA_GRACE_ANCHOR
+    if resolver is None:
+        return _match_tz(getattr(user, "date_joined", None))
+    if isinstance(resolver, str):
+        resolver = _import(resolver)
+    return _match_tz(resolver(user))
+
+
+def required_at(user):
+    """When this user starts being walled, or None for 'already'.
+
+    max(), not min(): a user who joined before MFA_REQUIRED_FROM is governed
+    by the cutover, while one who signs up after it still gets their full
+    MFA_GRACE_PERIOD. That union is the whole reason no per-user row is
+    needed to model this.
+    """
+    candidates = []
+
+    cutover = _as_datetime(mfa_settings.MFA_REQUIRED_FROM)
+    if cutover is not None:
+        candidates.append(cutover)
+
+    period = _period()
+    if period is not None:
+        anchor = _anchor(user)
+        if anchor is not None:
+            candidates.append(anchor + period)
+
+    return max(candidates) if candidates else None
+
+
+def _applies(user):
+    """Would this user be walled, ignoring grace?
+
+    Used by grace_state() so it can ask "would be walled" without an
+    `ignore_grace=` keyword on a security predicate -- a keyword that flips
+    a security answer is a footgun however carefully it is documented.
+    """
+    return _predicate_matches(user) and not has_active_exemption(user)
+
+
+def grace_state(user):
+    """GraceState while this user is in grace, else None.
+
+    Returns a value ONLY when the user would be walled but is not yet:
+    the predicate matched, no exemption is in force, and required_at is
+    still in the future. None both for users the policy never covers and for
+    users already past due -- which is what stops a banner appearing for
+    somebody the policy does not apply to, and what lets mfa_report use
+    `mfa_required_for(u) or grace_state(u) is not None` as its filter.
+
+    Unlike the grace check inside mfa_required_for(), this pays for the
+    predicate and the exemption lookup itself, because it is called
+    standalone (context processor, mfa_report, mfa_status) and has to answer
+    "would this user be walled" from scratch.
+    """
+    if not _applies(user):
+        return None
+    due = required_at(user)
+    if due is None:
+        return None
+    now = timezone.now()
+    if now >= due:
+        return None
+    return GraceState(
+        required_at=due,
+        days_remaining=math.ceil(
+            (due - now) / datetime.timedelta(days=1)))

--- a/django_mfa/tests/support/protected_admin_urls.py
+++ b/django_mfa/tests/support/protected_admin_urls.py
@@ -1,0 +1,33 @@
+"""Root URLconf for ProtectedAdminTests / AdminStepUpTests (test_admin.py).
+
+Deliberately a SEPARATE module from support/admin_urls.py, which
+AuthenticatorAdminHttpTests and UnprotectedAdminTests use and which never
+calls protect_admin_site(). AdminSite.get_urls() wires most admin views
+through a wrap() closure that reads self.has_permission fresh on every
+request, but `login/` is the one exception -- it is routed straight to
+`self.login`, evaluated exactly once, at whatever moment `admin.site.urls`
+is first accessed. Because Python caches an imported module in sys.modules
+and never re-executes its top-level code, that one evaluation is permanent
+for the life of the process.
+
+Fix round 1, Finding 5: the first version of this module relied on test
+setUp() to call protect_admin_site() before the first request -- which only
+works if ProtectedAdminTests happens to run before any other test imports
+this same module, i.e. it was order-dependent (confirmed broken under
+`--reverse`). Patching HERE, before `admin.site.urls` is read below,
+guarantees the `login/` URL captures the protected view no matter which
+test class imports this module first. protect_admin_site() is idempotent,
+so a test's own setUp() calling it again is a no-op.
+"""
+
+from django.contrib import admin
+from django.urls import include, path
+
+from django_mfa.admin_site import protect_admin_site
+
+protect_admin_site(admin.site)
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("", include("django_mfa.urls")),
+]

--- a/django_mfa/tests/test_admin.py
+++ b/django_mfa/tests/test_admin.py
@@ -8,13 +8,48 @@
 # permission could plant a secret of its own choosing. Note that
 # MFA_SECRET_ENCRYPTION_KEYS is no defence here -- django_mfa.crypto signs,
 # it does not encrypt, and the payload is recoverable without any key.
+import time
+
 from django.contrib import admin
 from django.contrib.auth.models import Permission, User
 from django.test import Client, RequestFactory, TestCase, override_settings
+from django.urls import reverse
 
+from django_mfa import session
+from django_mfa.admin_site import protect_admin_site
 from django_mfa.models import Authenticator
 
 SECRET = "JBSWY3DPEHPK3PXPCANARY"
+
+# test_runner.py's MIDDLEWARE, minus MfaMiddleware. ProtectedAdminTests and
+# AdminStepUpTests use this deliberately: the admin's own headline claim is
+# that it holds with NO middleware installed at all, and the suite's default
+# MIDDLEWARE includes MfaMiddleware -- which, combined with MFA_PROTECT_ADMIN
+# making policy.resolve() effectively cover is_staff users, would produce
+# every asserted redirect on its own regardless of whether protect_admin_site()
+# does anything. Without this override those tests pass even with the patch
+# suppressed entirely (verified: fix round 1, Finding 3).
+NO_MFA_MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+
+class FakeRequest:
+    """The minimal object session.mark_verified() needs: something with a
+    mutable .session. Lets a test drive the real session store behind
+    self.client (a SessionStore, not a plain dict) through session.py's own
+    API rather than writing to request.session["mfa"] directly -- session.py
+    is the only module allowed to touch that key's shape.
+    """
+
+    def __init__(self, session):
+        self.session = session
 
 
 class AuthenticatorAdminTests(TestCase):
@@ -106,3 +141,169 @@ class AuthenticatorAdminHttpTests(TestCase):
             {"post": "yes"})
         self.assertEqual(response.status_code, 302)
         self.assertFalse(Authenticator.objects.filter(pk=self.row.pk).exists())
+
+
+@override_settings(ROOT_URLCONF="django_mfa.tests.support.protected_admin_urls",
+                   MFA_PROTECT_ADMIN=True, MIDDLEWARE=NO_MFA_MIDDLEWARE)
+class ProtectedAdminTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_superuser(
+            "staff@example.com", "staff@example.com", "pw")
+        Authenticator.objects.create(
+            user=self.staff, type="totp", data={"secret": SECRET})
+        protect_admin_site(admin.site)
+        self.addCleanup(self._unpatch)
+
+    def _unpatch(self):
+        # admin.site is a django.utils.functional.LazyObject (see
+        # django.contrib.admin.sites.DefaultAdminSite): its own __dict__
+        # holds nothing but `_wrapped`, and every attribute set through the
+        # proxy -- including protect_admin_site()'s patches -- lands on the
+        # real AdminSite instance underneath. Popping from admin.site.__dict__
+        # directly is therefore a silent no-op that leaves the patch in
+        # place for every later test.
+        real_site = admin.site._wrapped
+        for attr in ("has_permission", "login", "_django_mfa_protected"):
+            real_site.__dict__.pop(attr, None)
+
+    def _verify(self):
+        s = self.client.session
+        session.mark_verified(FakeRequest(s), "totp")
+        s.save()
+
+    def test_unverified_staff_cannot_reach_the_admin_index(self):
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("admin:index"))
+        self.assertEqual(response.status_code, 302)
+
+    def test_unverified_staff_land_on_mfa_verify_not_the_admin_login_form(self):
+        """django-two-factor-auth's long-standing wart: an already
+        authenticated user being shown a login form.
+
+        startswith, not exact equality: the redirect carries a `?next=...`
+        query string (enforcement_redirect()'s own doing, via
+        redirect_to_login()), so the redirect-chain entry is never exactly
+        equal to the bare reverse()'d path.
+        """
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("admin:index"), follow=True)
+        self.assertTrue(any(
+            url.startswith(reverse("mfa:verify"))
+            for url, _ in response.redirect_chain))
+
+    def test_verified_staff_get_in(self):
+        self.client.force_login(self.staff)
+        self._verify()
+        self.assertEqual(
+            self.client.get(reverse("admin:index")).status_code, 200)
+
+    def test_factorless_staff_are_sent_to_the_security_page(self):
+        Authenticator.objects.filter(user=self.staff).delete()
+        self.client.force_login(self.staff)
+        response = self.client.get(reverse("admin:index"), follow=True)
+        self.assertTrue(any(
+            url.startswith(reverse("mfa:security_settings"))
+            for url, _ in response.redirect_chain))
+
+    def test_anonymous_still_sees_the_normal_admin_login_form(self):
+        self.assertEqual(
+            self.client.get(reverse("admin:login")).status_code, 200)
+
+    def test_patching_twice_is_a_no_op(self):
+        before = admin.site.has_permission
+        protect_admin_site(admin.site)
+        self.assertIs(admin.site.has_permission, before)
+
+    def test_login_view_still_declares_itself_login_not_required(self):
+        """Fix round 1, Finding 1 (and fix round 2: the first version of this
+        test was a false safety net -- see below).
+
+        AdminSite.login is decorated @login_not_required (Django >= 5.1),
+        and LoginRequiredMiddleware reads that marker off the URL pattern's
+        callable -- not off the AdminSite instance -- to decide whether an
+        anonymous request may reach admin:login at all. Critically, the
+        middleware's own default for a MISSING marker is `True` (i.e.
+        "login required"):
+
+            if not getattr(view_func, "login_required", True): ...
+
+        so an absent attribute is the FAILURE mode, not a safe stand-in for
+        an explicit False -- exactly what the reviewer's empirical run
+        showed (`login_required attr: MISSING` -> 302 away from the login
+        page). protect_admin_site()'s replacement view must therefore carry
+        the ORIGINAL's marker forward via functools.update_wrapper(), and
+        this test has to compare against that original rather than hard-
+        coding an expectation, or `getattr(..., False)` masks exactly the
+        regression it exists to catch (a bare `assertIsNot(..., True)`
+        against a default of False passes whether or not the attribute
+        survived the patch -- verified by mutation, see the round-2 report
+        entry).
+
+        Comparing against AdminSite.login directly (not a hard-coded
+        True/False/absent) keeps this correct across the Django floor: on
+        >= 5.1 both sides are False; on 4.2, where LoginRequiredMiddleware
+        does not exist, both sides are equally absent and the comparison
+        passes trivially -- which is correct, since there is nothing to
+        protect against on that version.
+        """
+        from django.contrib.admin.sites import AdminSite
+
+        missing = object()
+        self.assertEqual(
+            getattr(admin.site.login, "login_required", missing),
+            getattr(AdminSite.login, "login_required", missing))
+
+
+@override_settings(ROOT_URLCONF="django_mfa.tests.support.protected_admin_urls",
+                   MFA_PROTECT_ADMIN=True, MFA_ADMIN_STEPUP=True,
+                   MFA_STEPUP_MAX_AGE=60, MIDDLEWARE=NO_MFA_MIDDLEWARE)
+class AdminStepUpTests(TestCase):
+    """MFA_ADMIN_STEPUP -- fix round 1, Finding 4. Untested before this: the
+    re-prompt after MFA_STEPUP_MAX_AGE is the one piece of _login_redirect()
+    not delegated wholesale to decorators.enforcement_redirect().
+    """
+
+    def setUp(self):
+        self.staff = User.objects.create_superuser(
+            "stepup@example.com", "stepup@example.com", "pw")
+        Authenticator.objects.create(
+            user=self.staff, type="totp", data={"secret": SECRET})
+        protect_admin_site(admin.site)
+        self.addCleanup(self._unpatch)
+        self.client.force_login(self.staff)
+
+    def _unpatch(self):
+        real_site = admin.site._wrapped
+        for attr in ("has_permission", "login", "_django_mfa_protected"):
+            real_site.__dict__.pop(attr, None)
+
+    def _verify_at(self, at):
+        s = self.client.session
+        session.mark_verified(FakeRequest(s), "totp")
+        state = s["mfa"]
+        state["at"] = at
+        s["mfa"] = state
+        s.save()
+
+    def test_a_fresh_challenge_is_admitted(self):
+        self._verify_at(int(time.time()))
+        self.assertEqual(
+            self.client.get(reverse("admin:index")).status_code, 200)
+
+    def test_a_stale_challenge_is_sent_back_through_verify(self):
+        # MFA_STEPUP_MAX_AGE=60 above; 120s old is comfortably past it.
+        self._verify_at(int(time.time()) - 120)
+        response = self.client.get(reverse("admin:index"), follow=True)
+        self.assertTrue(any(
+            url.startswith(reverse("mfa:verify"))
+            for url, _ in response.redirect_chain))
+
+
+@override_settings(ROOT_URLCONF="django_mfa.tests.support.admin_urls")
+class UnprotectedAdminTests(TestCase):
+    def test_admin_is_untouched_when_the_setting_is_off(self):
+        staff = User.objects.create_superuser(
+            "s2@example.com", "s2@example.com", "pw")
+        self.client.force_login(staff)
+        self.assertEqual(
+            self.client.get(reverse("admin:index")).status_code, 200)

--- a/django_mfa/tests/test_api.py
+++ b/django_mfa/tests/test_api.py
@@ -7,6 +7,7 @@ keep working when broken, and neither is visible from the outside, so most
 of what is here is about refusals rather than happy paths.
 """
 
+import datetime
 import json
 import time
 
@@ -722,3 +723,25 @@ class TokenSessionTests(TestCase):
         self.assertEqual(response.status_code, 501)
         self.assertEqual(json.loads(response.content)["error"]["code"],
                          "token_sessions_unsupported")
+
+
+# ROOT_URLCONF=API_URLS is required here (unlike a bare TestCase) because the
+# suite's default ROOT_URLCONF (django_mfa.urls) never mounts the API at all
+# -- see ApiNotMountedTests above -- so reverse("mfa_api:state") would raise
+# NoReverseMatch before the assertion under test ever ran.
+@override_settings(ROOT_URLCONF=API_URLS)
+class StateGraceTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("g", "g@example.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_grace_is_null_by_default(self):
+        response = self.client.get(reverse("mfa_api:state"))
+        self.assertIsNone(response.json()["grace"])
+
+    @override_settings(MFA_REQUIRED=True,
+                       MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_grace_reports_the_deadline(self):
+        payload = self.client.get(reverse("mfa_api:state")).json()["grace"]
+        self.assertTrue(payload["required_at"].startswith("2099-01-01"))
+        self.assertGreater(payload["days_remaining"], 0)

--- a/django_mfa/tests/test_commands.py
+++ b/django_mfa/tests/test_commands.py
@@ -1,4 +1,6 @@
-from datetime import datetime, timedelta
+import csv
+import datetime
+from datetime import timedelta
 from datetime import timezone as dt_timezone
 from io import StringIO
 
@@ -116,7 +118,7 @@ class MfaStatusTests(TestCase):
         # not the command actually converts to local time first, so it
         # couldn't discriminate a regression back to a bare strftime on the
         # stored (UTC) value -- this timestamp can.
-        created_at = datetime(2024, 1, 1, 23, 0, tzinfo=dt_timezone.utc)
+        created_at = datetime.datetime(2024, 1, 1, 23, 0, tzinfo=dt_timezone.utc)
         Authenticator.objects.create(
             user=self.user, type=Authenticator.Type.TOTP,
             data={"secret": encrypt(KNOWN_SECRET)}, created_at=created_at)
@@ -285,7 +287,7 @@ class MfaReportTests(TestCase):
         # still printed above the header.
         output = self._run("--format", "csv")
         first_line = output.splitlines()[0]
-        self.assertEqual(first_line, "pk,username")
+        self.assertEqual(first_line, "pk,username,grace_until")
 
     def test_never_prints_factor_data(self):
         self.assertNotIn(KNOWN_SECRET, self._run())
@@ -348,3 +350,28 @@ class MfaPruneTests(TestCase):
         out = StringIO()
         call_command("mfa_prune", stdout=out)
         self.assertIn("expire themselves", out.getvalue())
+
+
+@override_settings(MFA_REQUIRED=True, MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+class GraceReportingTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("g", "g@example.com", "pw")
+
+    def test_mfa_status_shows_the_grace_line(self):
+        out = StringIO()
+        call_command("mfa_status", "g", stdout=out)
+        self.assertIn("In grace until 2099-01-01", out.getvalue())
+
+    def test_in_grace_users_still_appear_in_the_report(self):
+        """A rollout report that hides the people still in their window is
+        useless -- those are exactly who it exists to show."""
+        out = StringIO()
+        call_command("mfa_report", stdout=out)
+        self.assertIn("g", out.getvalue())
+
+    def test_csv_carries_a_grace_until_column(self):
+        out = StringIO()
+        call_command("mfa_report", "--format", "csv", stdout=out)
+        rows = list(csv.reader(StringIO(out.getvalue())))
+        self.assertEqual(rows[0][-1], "grace_until")
+        self.assertTrue(rows[1][-1].startswith("2099-01-01"))

--- a/django_mfa/tests/test_conf.py
+++ b/django_mfa/tests/test_conf.py
@@ -1,13 +1,22 @@
+import datetime
+from unittest.mock import patch
+
 from django.test import TestCase, override_settings
 
 from django_mfa.checks import (
+    check_admin_stepup,
     check_client_ip_resolver,
     check_fido2_rp_id,
+    check_grace_configuration,
     check_rate_limit_backend,
     check_rate_limit_specs,
     check_webauthn_backend_configured,
 )
 from django_mfa.conf import settings as mfa_settings
+
+#: A dotted path to this resolves to something that isn't callable, for
+#: test_non_callable_anchor_is_an_error below.
+NOT_CALLABLE = object()
 
 
 class ConfTests(TestCase):
@@ -65,6 +74,99 @@ class ChecksTests(TestCase):
         """
         self._unregister_webauthn()
         self.assertEqual(check_fido2_rp_id(app_configs=None), [])
+
+    def test_no_grace_settings_is_fine(self):
+        self.assertEqual(check_grace_configuration(app_configs=None), [])
+
+    @override_settings(MFA_GRACE_PERIOD=14)
+    def test_grace_period_with_date_joined_is_fine(self):
+        self.assertEqual(check_grace_configuration(app_configs=None), [])
+
+    @override_settings(MFA_GRACE_PERIOD=-1)
+    def test_negative_period_is_an_error(self):
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    @override_settings(MFA_REQUIRED_FROM="2026-09-01")
+    def test_a_string_cutover_is_an_error(self):
+        """A silent no-grace failure is the worst outcome this feature has."""
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2026, 9, 1))
+    def test_a_date_cutover_is_fine(self):
+        self.assertEqual(check_grace_configuration(app_configs=None), [])
+
+    @override_settings(MFA_GRACE_PERIOD=14)
+    def test_grace_period_with_no_anchor_and_no_date_joined_is_an_error(self):
+        """Drives the anchor-check elif branch to its failing form. checks.py
+        calls get_user_model() *inside* the function (imported there, not at
+        module scope), so the patch target is
+        django.contrib.auth.get_user_model -- patching
+        django_mfa.checks.get_user_model raises AttributeError, since no such
+        module attribute exists.
+        """
+        class NoDateJoined:
+            pass
+
+        with patch("django.contrib.auth.get_user_model", return_value=NoDateJoined):
+            errors = check_grace_configuration(app_configs=None)
+            self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+            with override_settings(MFA_GRACE_ANCHOR=lambda user: None):
+                self.assertEqual(check_grace_configuration(app_configs=None), [])
+
+    @override_settings(MFA_GRACE_PERIOD="14")
+    def test_non_numeric_period_is_an_error(self):
+        """A fat-fingered string ("14" instead of 14) must be reported like
+        every other bad setting in this module, not raise a bare TypeError
+        out of `period < 0`.
+        """
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    @override_settings(
+        MFA_GRACE_PERIOD=14,
+        MFA_GRACE_ANCHOR="django_mfa.tests.test_conf.this_module_does_not_exist_at_all")
+    def test_unimportable_anchor_is_an_error(self):
+        """MFA_GRACE_PERIOD is set here so this isolates the import failure
+        from test_anchor_without_period_is_an_error's condition below --
+        without it both errors would fire at once.
+        """
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    @override_settings(
+        MFA_GRACE_PERIOD=14,
+        MFA_GRACE_ANCHOR="django_mfa.tests.test_conf.NOT_CALLABLE")
+    def test_non_callable_anchor_is_an_error(self):
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    @override_settings(MFA_GRACE_PERIOD=14, MFA_GRACE_ANCHOR=lambda user: None)
+    def test_callable_anchor_with_period_is_fine(self):
+        self.assertEqual(check_grace_configuration(app_configs=None), [])
+
+    @override_settings(MFA_GRACE_PERIOD=None, MFA_GRACE_ANCHOR=lambda user: None)
+    def test_anchor_without_period_is_an_error(self):
+        """Same failure class as MFA_ADMIN_STEPUP without MFA_PROTECT_ADMIN
+        (E011): required_at() never calls _anchor() when _period() is None,
+        so the anchor is silently never consulted.
+        """
+        errors = check_grace_configuration(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E010"])
+
+    def test_neither_admin_setting_is_fine(self):
+        self.assertEqual(check_admin_stepup(app_configs=None), [])
+
+    @override_settings(MFA_PROTECT_ADMIN=True, MFA_ADMIN_STEPUP=True)
+    def test_both_together_is_fine(self):
+        self.assertEqual(check_admin_stepup(app_configs=None), [])
+
+    @override_settings(MFA_ADMIN_STEPUP=True)
+    def test_stepup_without_protect_admin_is_an_error(self):
+        errors = check_admin_stepup(app_configs=None)
+        self.assertEqual([e.id for e in errors], ["django_mfa.E011"])
 
 
 class MfaFactorsAdapterRegistrationTests(TestCase):

--- a/django_mfa/tests/test_decorators.py
+++ b/django_mfa/tests/test_decorators.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 
 from django.conf import settings as django_settings
@@ -7,6 +8,7 @@ from django.test import Client, RequestFactory, TestCase, override_settings
 from django.urls import include, path, reverse
 from django.views.generic import View
 
+from django_mfa import session as mfa_session
 from django_mfa.decorators import (
     PENDING,
     UNENROLLED,
@@ -221,3 +223,83 @@ class UnchallengedSessionTests(TestCase):
         Authenticator.objects.create(
             user=self.user, type=Authenticator.Type.RECOVERY_CODES, data={})
         self.assertEqual(enforcement_state(self._request()), UNENROLLED)
+
+
+@override_settings(ROOT_URLCONF="django_mfa.tests.test_decorators",
+                   LOGIN_URL="/login/", MFA_REQUIRED=True,
+                   MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+class GraceDoesNotOpenDecoratedViewsTests(TestCase):
+    """The load-bearing test for this feature.
+
+    Grace suppresses MFA_REQUIRED only -- exactly as an MfaExemption does.
+    MFA_REQUIRED picks users, the decorator picks views, and an in-grace user
+    reaching a decorated billing page is still redirected. If grace is ever
+    moved into decorators.enforcement_state(), THIS is what fails, instead of
+    a billing page quietly opening.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user("g@example.com", password="pw")
+        self.client = Client()
+        self.decorated_url = reverse("protected")
+
+    def test_mfa_required_still_blocks_an_in_grace_user(self):
+        self.client.login(username="g@example.com", password="pw")
+        response = self.client.get(self.decorated_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("mfa:security_settings"), response["Location"])
+
+
+@override_settings(ROOT_URLCONF="django_mfa.tests.test_decorators",
+                   LOGIN_URL="/login/")
+class EnforcementRedirectTests(TestCase):
+    """decorators.enforcement_redirect(), the public form _enforce() wraps.
+
+    No verified_request/pending_request helpers exist elsewhere in this
+    module, so these are built the same way UnchallengedSessionTests._request
+    builds its requests: RequestFactory plus session.start_pending/
+    mark_verified directly, rather than a new fixture style.
+    """
+
+    def setUp(self):
+        self.user = User.objects.create_user("r@example.com", password="pw")
+        self.factory = RequestFactory()
+        Authenticator.objects.create(
+            user=self.user, type=Authenticator.Type.TOTP, data={})
+
+    def _request(self):
+        request = self.factory.get("/somewhere/")
+        request.user = self.user
+        request.session = {}
+        return request
+
+    def verified_request(self):
+        request = self._request()
+        mfa_session.mark_verified(request, "totp")
+        return request
+
+    def pending_request(self):
+        request = self._request()
+        mfa_session.start_pending(request)
+        return request
+
+    def test_returns_none_for_a_verified_request(self):
+        from django_mfa import decorators
+
+        request = self.verified_request()   # reuse this module's existing helper
+        self.assertIsNone(decorators.enforcement_redirect(request))
+
+    def test_next_url_overrides_the_current_path(self):
+        """Task 8 needs this: the admin bounces off /admin/login/, and
+        replaying that path after verification is a pointless round trip."""
+        from django_mfa import decorators
+
+        request = self.pending_request()    # reuse this module's existing helper
+        response = decorators.enforcement_redirect(request, next_url="/admin/")
+        # redirect_to_login() builds the querystring with urlencode(safe="/"),
+        # so the path separators in `next` survive unescaped -- "next=/admin/",
+        # not "next=%2Fadmin%2F". (The brief this test was transcribed from
+        # asserted the percent-encoded form; that does not match Django's
+        # actual QueryDict.urlencode(safe="/") behaviour in redirect_to_login,
+        # confirmed by running this test against the implementation above.)
+        self.assertIn("next=/admin/", response["Location"])

--- a/django_mfa/tests/test_enforcement.py
+++ b/django_mfa/tests/test_enforcement.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.contrib.auth import login as auth_login
 from django.contrib.auth.models import User
 from django.contrib.sessions.backends.db import SessionStore
@@ -385,6 +387,34 @@ class WallIsOffByDefaultTests(TestCase):
         client.login(username="b@example.com", password="pw")
         response = client.get("/some/other/page/")
         self.assertEqual(response.status_code, 404)
+
+
+@override_settings(MFA_REQUIRED=True)
+class GraceSuppressesTheEnrollmentWallTests(TestCase):
+    """policy.mfa_required_for() must return False for a user still inside
+    their MFA_GRACE_PERIOD/MFA_REQUIRED_FROM window -- the wall behaves as
+    though MFA_REQUIRED were off for them, exactly as it does for a user
+    covered by an MfaExemption (see EnrollmentWallTests/WallIsOffByDefaultTests
+    above, which this pairs with)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user("g@example.com", password="pw")
+        self.client = Client()
+        self.client.login(username="g@example.com", password="pw")
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_in_grace_user_is_not_walled(self):
+        response = self.client.get("/some/other/page/")
+        # No wall means the request falls through to plain URL resolution --
+        # 404, exactly as WallIsOffByDefaultTests asserts for MFA_REQUIRED
+        # being off entirely.
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2020, 1, 1))
+    def test_past_the_deadline_the_wall_returns(self):
+        response = self.client.get("/some/other/page/")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(reverse("mfa:security_settings"), response["Location"])
 
 
 class MfaRequiredQueryCostTests(TestCase):

--- a/django_mfa/tests/test_policy.py
+++ b/django_mfa/tests/test_policy.py
@@ -1,6 +1,9 @@
+import datetime
+
 from django.contrib.auth.models import Group, User
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from django_mfa import policy
 from django_mfa.checks import check_mfa_required_predicate
@@ -108,3 +111,196 @@ class ResolveTests(TestCase):
     def test_resolve_raises_on_a_nonsense_value(self):
         with self.assertRaises(ImproperlyConfigured):
             policy.resolve()
+
+
+JOINED = datetime.datetime(2026, 1, 10, 12, 0)
+
+
+def _joined(dt):
+    """A user whose date_joined is `dt`, timezone-matched to USE_TZ."""
+    user = User.objects.create_user("grace", "grace@example.com", "pw")
+    User.objects.filter(pk=user.pk).update(date_joined=policy._match_tz(dt))
+    user.refresh_from_db()
+    return user
+
+
+class RequiredAtTests(TestCase):
+    def test_no_settings_means_required_immediately(self):
+        """The default install must behave exactly as it does today."""
+        self.assertIsNone(policy.required_at(_joined(JOINED)))
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2026, 9, 1))
+    def test_cutover_only(self):
+        self.assertEqual(
+            policy.required_at(_joined(JOINED)),
+            policy._match_tz(datetime.datetime(2026, 9, 1, 0, 0)))
+
+    @override_settings(MFA_GRACE_PERIOD=14)
+    def test_period_only_counts_from_date_joined(self):
+        self.assertEqual(
+            policy.required_at(_joined(JOINED)),
+            policy._match_tz(JOINED + datetime.timedelta(days=14)))
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2026, 9, 1),
+                       MFA_GRACE_PERIOD=14)
+    def test_cutover_wins_for_a_user_who_joined_long_ago(self):
+        """max(), not min(): an old account is governed by the cutover."""
+        self.assertEqual(
+            policy.required_at(_joined(JOINED)),
+            policy._match_tz(datetime.datetime(2026, 9, 1, 0, 0)))
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2026, 9, 1),
+                       MFA_GRACE_PERIOD=14)
+    def test_personal_window_wins_for_a_user_who_joined_after_the_cutover(self):
+        """The cutover having passed must not cost a new joiner their window."""
+        late = datetime.datetime(2026, 10, 5, 9, 0)
+        self.assertEqual(
+            policy.required_at(_joined(late)),
+            policy._match_tz(late + datetime.timedelta(days=14)))
+
+    @override_settings(MFA_GRACE_PERIOD=datetime.timedelta(days=3))
+    def test_period_accepts_a_timedelta(self):
+        self.assertEqual(
+            policy.required_at(_joined(JOINED)),
+            policy._match_tz(JOINED + datetime.timedelta(days=3)))
+
+    @override_settings(MFA_GRACE_PERIOD=14,
+                       MFA_GRACE_ANCHOR="django_mfa.tests.test_policy.anchor_none")
+    def test_anchor_returning_none_falls_back_to_cutover_only(self):
+        self.assertIsNone(policy.required_at(_joined(JOINED)))
+
+    @override_settings(MFA_GRACE_PERIOD=14,
+                       MFA_GRACE_ANCHOR="django_mfa.tests.test_policy.anchor_fixed")
+    def test_dotted_path_anchor_is_used_instead_of_date_joined(self):
+        self.assertEqual(
+            policy.required_at(_joined(JOINED)),
+            policy._match_tz(
+                datetime.datetime(2026, 6, 1, 0, 0) + datetime.timedelta(days=14)))
+
+    @override_settings(MFA_GRACE_PERIOD=14)
+    def test_user_model_without_date_joined_gets_no_personal_window(self):
+        class Anon:
+            is_authenticated = True
+
+        self.assertIsNone(policy.required_at(Anon()))
+
+    @override_settings(MFA_REQUIRED_FROM="2026-09-01")
+    def test_cutover_of_the_wrong_type_raises(self):
+        """A string is not a date or datetime -- _as_datetime must say so
+        rather than fail confusingly on a later comparison against
+        timezone.now()."""
+        with self.assertRaises(ImproperlyConfigured):
+            policy.required_at(_joined(JOINED))
+
+
+def anchor_none(user):
+    return None
+
+
+def anchor_fixed(user):
+    return datetime.datetime(2026, 6, 1, 0, 0)
+
+
+@override_settings(MFA_REQUIRED=True)
+class GraceStateTests(TestCase):
+    def setUp(self):
+        self.user = _joined(JOINED)
+
+    def test_none_when_no_grace_is_configured(self):
+        self.assertIsNone(policy.grace_state(self.user))
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2020, 1, 1))
+    def test_none_once_the_deadline_has_passed(self):
+        self.assertIsNone(policy.grace_state(self.user))
+
+    @override_settings(MFA_REQUIRED=False,
+                       MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_none_for_a_user_the_policy_does_not_cover(self):
+        """No banner for someone who would never be walled anyway."""
+        self.assertIsNone(policy.grace_state(self.user))
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_reports_the_deadline_while_in_grace(self):
+        state = policy.grace_state(self.user)
+        self.assertEqual(
+            state.required_at, policy._match_tz(datetime.datetime(2099, 1, 1, 0, 0)))
+        self.assertGreater(state.days_remaining, 0)
+
+    def test_days_remaining_rounds_up(self):
+        """23 hours left must read '1 day', never '0' -- 0 reads as expired."""
+        soon = timezone.now() + datetime.timedelta(hours=23)
+        with override_settings(MFA_REQUIRED_FROM=soon):
+            self.assertEqual(policy.grace_state(self.user).days_remaining, 1)
+
+
+def anchor_aware(user):
+    """An anchor resolver returning an aware datetime -- see
+    MatchTzUseTzFalseTests for why this exists."""
+    return datetime.datetime(2099, 1, 1, tzinfo=datetime.timezone.utc)
+
+
+class MatchTzUseTzFalseTests(TestCase):
+    """_match_tz's `not USE_TZ and is_aware(value)` branch.
+
+    test_runner.py pins USE_TZ=True globally, so nothing above this class
+    ever hits that branch -- every value either starts naive already or is
+    made aware. Mirrors MfaDisableUntilUseTzTests' pattern (test_exemptions.py):
+    pin USE_TZ=False with override_settings and drive the real, public entry
+    points (required_at/grace_state) end-to-end, rather than calling the
+    private helper directly. TIME_ZONE is pinned to UTC alongside USE_TZ so
+    the aware -> naive conversion is a plain tzinfo strip with no hour shift,
+    keeping the expected values simple. Far-future dates (2099) keep
+    grace_state() from reading as already-passed regardless of when the
+    suite runs.
+    """
+
+    @override_settings(
+        USE_TZ=False, TIME_ZONE="UTC",
+        MFA_REQUIRED_FROM=datetime.datetime(
+            2099, 1, 1, tzinfo=datetime.timezone.utc))
+    def test_required_at_converts_an_aware_cutover_to_naive(self):
+        due = policy.required_at(_joined(JOINED))
+        self.assertTrue(timezone.is_naive(due))
+        self.assertEqual(due, datetime.datetime(2099, 1, 1, 0, 0))
+
+    @override_settings(
+        USE_TZ=False, TIME_ZONE="UTC", MFA_REQUIRED=True,
+        MFA_GRACE_PERIOD=1,
+        MFA_GRACE_ANCHOR="django_mfa.tests.test_policy.anchor_aware")
+    def test_grace_state_converts_an_aware_anchor_to_naive(self):
+        state = policy.grace_state(_joined(JOINED))
+        self.assertTrue(timezone.is_naive(state.required_at))
+        self.assertEqual(state.required_at, datetime.datetime(2099, 1, 2, 0, 0))
+
+
+class ProtectAdminUnionTests(TestCase):
+    def setUp(self):
+        self.staff = User.objects.create_user(
+            "s", "s@example.com", "pw", is_staff=True)
+        self.plain = User.objects.create_user("p", "p@example.com", "pw")
+
+    def test_off_by_default(self):
+        self.assertIsNone(policy.resolve())
+
+    @override_settings(MFA_PROTECT_ADMIN=True)
+    def test_staff_are_required_with_no_other_policy(self):
+        self.assertTrue(policy.resolve()(self.staff))
+        self.assertFalse(policy.resolve()(self.plain))
+
+    @override_settings(MFA_PROTECT_ADMIN=True,
+                       MFA_REQUIRED="django_mfa.tests.test_policy.only_p")
+    def test_union_with_an_existing_predicate(self):
+        self.assertTrue(policy.resolve()(self.staff))
+        self.assertTrue(policy.resolve()(self.plain))
+
+    @override_settings(MFA_PROTECT_ADMIN=True)
+    def test_the_union_is_not_cached_across_settings_changes(self):
+        """policy._import is @cache'd on the dotted path; the composed
+        predicate must NOT ride along or override_settings gets pinned."""
+        self.assertTrue(policy.resolve()(self.staff))
+        with override_settings(MFA_PROTECT_ADMIN=False):
+            self.assertIsNone(policy.resolve())
+
+
+def only_p(user):
+    return user.username == "p"

--- a/django_mfa/tests/test_views.py
+++ b/django_mfa/tests/test_views.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import json
 import os
 import re
@@ -6,7 +7,7 @@ import time
 import xml.etree.ElementTree as ET
 from unittest.mock import patch
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import AnonymousUser, User
 from django.core.cache import cache
 from django.http import HttpResponse
 from django.test import Client, RequestFactory, TestCase, override_settings
@@ -1309,3 +1310,89 @@ class IpBudgetThroughTheViewTests(TestCase):
                 scope__startswith="django_mfa:rl:ip:").get().count, 1)
         self.assertFalse(RateLimitCounter.objects.filter(
             scope=f"django_mfa:rl:{user.pk}:totp").exists())
+
+
+@override_settings(MFA_REQUIRED=True)
+class SecurityPageGraceContextTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user("g", "g@example.com", "pw")
+        self.client.force_login(self.user)
+
+    def test_no_grace_configured_means_none(self):
+        response = self.client.get(reverse("mfa:security_settings"))
+        self.assertIsNone(response.context["grace"])
+
+    @override_settings(MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_in_grace_exposes_the_deadline(self):
+        response = self.client.get(reverse("mfa:security_settings"))
+        self.assertIsNotNone(response.context["grace"])
+        self.assertGreater(response.context["grace"].days_remaining, 0)
+
+
+class ContextProcessorTests(TestCase):
+    """Note: assert truthiness, NOT identity.
+
+    `mfa_grace` is a SimpleLazyObject, and a SimpleLazyObject wrapping None
+    is not None -- verified: `SimpleLazyObject(lambda: None) is None` is
+    False, `== None` is True, `bool(...)` is False. assertIsNone would fail
+    against a correct implementation. Truthiness is also what a template
+    actually does with it (`{% if mfa_grace %}`), so it is the honest
+    assertion here.
+    """
+
+    def test_anonymous_request_resolves_to_nothing(self):
+        from django_mfa.context_processors import mfa
+
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        self.assertFalse(mfa(request)["mfa_grace"])
+
+    @override_settings(MFA_REQUIRED=True,
+                       MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_in_grace_user_gets_a_state(self):
+        from django_mfa.context_processors import mfa
+
+        request = RequestFactory().get("/")
+        request.user = User.objects.create_user("g", "g@example.com", "pw")
+        grace = mfa(request)["mfa_grace"]
+        self.assertTrue(grace)
+        self.assertGreater(grace.days_remaining, 0)
+
+    def test_anonymous_request_never_touches_policy(self):
+        """The short-circuit for an unauthenticated user happens in resolve()
+        itself, before policy.grace_state() is ever reached -- not merely a
+        return value that happens to also be None if grace_state() ran
+        (AnonymousUser would make _predicate_matches() return False too, so
+        that outcome alone can't distinguish the two). Mock the call and
+        prove it never fires, even once the lazy value is forced.
+        """
+        from django_mfa.context_processors import mfa
+
+        request = RequestFactory().get("/")
+        request.user = AnonymousUser()
+        with patch("django_mfa.policy.grace_state") as mock_grace_state:
+            result = mfa(request)["mfa_grace"]
+            self.assertFalse(result)
+            mock_grace_state.assert_not_called()
+
+    @override_settings(MFA_REQUIRED=True,
+                       MFA_REQUIRED_FROM=datetime.date(2099, 1, 1))
+    def test_mfa_grace_is_lazy(self):
+        """Pin the structure, not just the outcome: policy.grace_state() must
+        not run until mfa_grace is actually forced. This is the property
+        that makes it safe to run this context processor on every template
+        render -- a host using policy.in_groups(...) pays a database query
+        inside grace_state(), and a template that never mentions mfa_grace
+        must not pay for it. If someone "simplified" context_processors.mfa()
+        by inlining the closure into a direct policy.grace_state(user) call,
+        every other test here would still pass; only this one would catch it.
+        """
+        from django_mfa.context_processors import mfa
+
+        request = RequestFactory().get("/")
+        request.user = User.objects.create_user("g", "g@example.com", "pw")
+        with patch("django_mfa.policy.grace_state") as mock_grace_state:
+            result = mfa(request)["mfa_grace"]
+            mock_grace_state.assert_not_called()
+            bool(result)
+            mock_grace_state.assert_called_once_with(request.user)

--- a/django_mfa/views/manage.py
+++ b/django_mfa/views/manage.py
@@ -42,6 +42,10 @@ def security_settings(request):
             policy.resolve()
             and not registry.has_primary_factor(request.user)
             and policy.mfa_required_for(request.user)),
+        # None unless this user would be walled but is not yet. The template
+        # can say "you have N days"; nothing here enforces against it --
+        # see policy.GraceState.
+        "grace": policy.grace_state(request.user),
     }
     return render(request, "django_mfa/security.html", context)
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -76,6 +76,7 @@ what the `{% extends base_template %}` line at the top resolves.
 | `recovery_codes_remaining` | Integer count of unused codes. |
 | `owned_by_enterprise` | The `MFA_OWNED_BY_ENTERPRISE` setting, so the template can hide the remove button for WebAuthn. |
 | `mfa_enrollment_required` | `True` only when this user is both required to hold a factor (`MFA_REQUIRED`, see {doc}`enforcement`) and holds none yet — i.e. exactly when `MfaMiddleware` walled them onto this page. If you shadow this template, render something here: without it, a required user lands on a security page that gives no reason for the wall they just hit. |
+| `grace` | A `policy.GraceState` (`required_at`, `days_remaining`) when this user would be required to enrol but is not yet, else `None`. |
 
 ### `picker.html`
 

--- a/docs/enforcement.md
+++ b/docs/enforcement.md
@@ -64,6 +64,67 @@ at all — Django's admin emits no signal of its own for it that django-mfa
 listens for. If the deletion needs to appear in whatever is consuming that
 signal, use `mfa_disable --revoke`, not the admin.
 
+### Rolling it out
+
+Turning `MFA_REQUIRED` on for a project with existing users is rarely a flag
+day — "everyone must have a second factor starting next month" needs a ramp,
+not an instant wall. `MFA_REQUIRED_FROM` and `MFA_GRACE_PERIOD` give you one:
+
+    MFA_REQUIRED_FROM = datetime.date(2026, 9, 1)   # nobody is walled before this
+    MFA_GRACE_PERIOD = 14                            # ...then 14 days per user, from their own anchor
+
+A user is required from **whichever of `MFA_REQUIRED_FROM` and
+`anchor + MFA_GRACE_PERIOD` is later** — `max()`, not `min()`. That single
+rule, evaluated per user, covers both halves of a rollout at once:
+
+- **Alice signed up in 2024**, long before the cutover. Her anchor (by
+  default `alice.date_joined`) plus 14 days is already in the past, so
+  `MFA_REQUIRED_FROM` alone decides: she's walled on 2026-09-01, the same day
+  as every other existing user.
+- **Bob signs up on 2026-09-10**, after the cutover has already passed. If
+  `MFA_REQUIRED_FROM` alone decided, he'd be walled on his very first login —
+  the date has already come and gone. Instead `anchor + MFA_GRACE_PERIOD`
+  wins the `max()`, so Bob gets his own full 14 days from the day he joined,
+  same as anyone who signs up after the ramp is over.
+
+`policy.required_at(user)` returns that date (or `None` if neither setting
+applies to the user at all), and `policy.grace_state(user)` returns a
+`GraceState(required_at, days_remaining)` while the user is inside their
+window — `None` once the policy doesn't apply to them, or once `required_at`
+has passed and they're actually walled. `days_remaining` is rounded up and is
+for display only; nothing enforces against it, only against `required_at`
+itself.
+
+`MFA_GRACE_ANCHOR` exists for the clock `date_joined` can't express: a
+dotted path or callable, `(user) -> datetime | None`, for a per-user start
+date that isn't "when the account was created" — the day a cohort was
+migrated in, or the day a user's plan changed to require 2FA. Return `None`
+for a user you have no anchor for; they simply fall back to
+`MFA_REQUIRED_FROM` alone.
+
+The grace state is surfaced in five places: `security_settings`'s own
+`grace` context key, the opt-in `django_mfa.context_processors.mfa` context
+processor (`mfa_grace`, for your own templates), the JSON API's `state`
+endpoint (`grace` field), `mfa_status`'s "In grace until" line, and
+`mfa_report`, which now lists in-grace users and appends a `grace_until`
+column to its CSV output — see the 4.6.0 entry in `CHANGELOG.md`.
+
+:::{warning}
+**Grace suppresses `MFA_REQUIRED` only — it does not open `@mfa_required`
+views, or the admin gate under `MFA_PROTECT_ADMIN`.** Exactly like an
+`MfaExemption` above, a user still inside their grace window is left alone
+by the enrollment wall, but a view behind `@mfa_required`/`MfaRequiredMixin`
+still refuses them, and so does `/admin/` when `MFA_PROTECT_ADMIN` is on:
+both are enforced through `decorators.enforcement_state()`, which is itself
+the policy for what it gates and never consults `MFA_REQUIRED` or grace at
+all — it decides purely from the session and the registry, with no import
+of `django_mfa.policy`. A billing page gated with `@mfa_required`, and every
+admin page once `MFA_PROTECT_ADMIN = True`, requires a factor from every
+user who reaches it, cutover or not. See
+[Protecting the admin](#protecting-the-admin) below for what that means in
+practice.
+:::
+
 ## What a required user sees
 
 A user `MFA_REQUIRED` applies to, who holds no *primary* factor yet
@@ -185,6 +246,102 @@ nothing to re-verify yet, and gating that view would lock them out of the
 only pages that could give them a factor. Most host-project views should
 leave this at its default.
 
+## Protecting the admin
+
+    MFA_PROTECT_ADMIN = True
+
+is the one-liner: no page on `django.contrib.admin`'s default site
+(`django.contrib.admin.site`) is reachable without a verified session. Two
+things about it are easy to miss — plus a scope limit worth knowing before
+you rely on it, covered in [What is not enforced](#what-is-not-enforced)
+below.
+
+**It is enforced by the admin site itself, not by `MfaMiddleware`.**
+`django_mfa.admin_site.protect_admin_site()` wraps `admin.site.has_permission()`
+and `admin.site.login()` in place, from `DjangoMfaAppConfig.ready()`, whenever
+this setting is on — so the gate holds even on a project that never installed
+`MfaMiddleware` at all. `has_permission()` refuses an authenticated-but-unverified
+staff user outright on every ordinary admin page; `admin:login` is where that
+redirect lands (Django's own `AdminSite.admin_view` sends a failed
+`has_permission()` there), and the wrapped `login()` checks first whether
+this is actually an already-authenticated user rather than rendering the
+normal login form for one — if so, it redirects them through `mfa:verify`
+(or `mfa:security_settings`, for one holding no primary factor) instead, so
+they see the second-factor challenge rather than a login form as though
+they'd never signed in. An anonymous visitor is left alone entirely; the
+admin's own login form is still the right answer for them.
+
+**It also makes `MFA_REQUIRED` apply to staff — without a second setting.**
+`policy.resolve()` unions in `is_staff` whenever `MFA_PROTECT_ADMIN` is on:
+whatever `MFA_REQUIRED` is already set to (including its default, `False`)
+stays exactly as configured, and any `is_staff` user is *additionally*
+required, regardless of whether they match your own predicate. `MFA_PROTECT_ADMIN`
+does not rewrite `MFA_REQUIRED` itself — `mfa_status`, `mfa_report` and both
+`MfaMiddleware` rungs all go on reading `policy.resolve()` as normal, so
+nothing else needs to know the union happened.
+
+That union has a cost worth knowing. Turning `MFA_PROTECT_ADMIN` on makes
+`policy.resolve()` non-`None` — even for a project that never set
+`MFA_REQUIRED` at all — which activates `MfaMiddleware`'s second rung (the
+no-primary-factor wall described above), previously skipped unconditionally
+whenever `MFA_REQUIRED` was left at its default. Every authenticated request
+now pays `registry.has_primary_factor(request.user)`, one query, to find out
+whether it applies. This is deliberate — a staff user with no primary factor
+needs to be walled off the *rest* of the site too, not just `/admin/` — but
+it is a query every authenticated request now pays that it didn't before.
+
+`MFA_ADMIN_STEPUP = True` goes one step further: with `MFA_PROTECT_ADMIN`
+also on, the admin additionally requires a challenge completed within
+`MFA_STEPUP_MAX_AGE` (see [Step-up re-authentication](#step-up-re-authentication)
+above), not merely a verified session — the same freshness rung
+`mfa_recent_required` applies to django-mfa's own factor-mutating views,
+applied here to every admin page instead. Set on its own, without
+`MFA_PROTECT_ADMIN`, it does nothing at all: nothing reads it unless the
+admin site has actually been wrapped. `django_mfa.E011` catches exactly that
+misconfiguration at `manage.py check`.
+
+**Grace and `mfa_disable` exemptions do not apply to this gate, at all.**
+`MFA_REQUIRED_FROM`/`MFA_GRACE_PERIOD` and `manage.py mfa_disable` both work
+by suppressing `policy.mfa_required_for(user)` — a question about *users*,
+answered by `django_mfa.policy`. The admin gate is not that question: like
+`@mfa_required` (see the warning under [Rolling it out](#rolling-it-out)
+above), it is enforced through `decorators.enforcement_state()`, which is
+itself the policy for what it gates and is deliberately written to never
+import `django_mfa.policy` — grace and exemptions simply don't exist as far
+as it's concerned. With `MFA_PROTECT_ADMIN = True`, a staff user holding no
+primary factor is walled out of every admin page from the moment it's
+deployed — not from your announced cutover, and not once you've run
+`mfa_disable` for them. There is no ramp and no exemption for `/admin/`
+itself, whatever `MFA_REQUIRED_FROM` or an active `MfaExemption` says about
+the rest of the site.
+
+This is a real trap while debugging, because `manage.py mfa_status alice`
+reads `policy.mfa_required_for()` — the same question the rest of the site
+asks — and will happily print `Required: no`, or `Exempt: <reason>`, or an
+"in grace until" line, for a user `/admin/` still refuses outright. Treat
+`mfa_status`'s answer as describing `MFA_REQUIRED` only, never as a
+prediction of what the admin gate will do once `MFA_PROTECT_ADMIN` is on.
+
+:::{warning}
+**The admin's own "Log out" link is not a way out of this gate.** `admin:logout`
+is itself an admin URL, rendered through the same `admin_view()` wrapper as
+every other admin page — and Django's own `AdminSite.admin_view` special-cases
+a failed `has_permission()` on that exact path by redirecting back to
+`admin:index` instead of calling `logout()` at all. A staff user who is
+walled — pending verification, or required and holding no primary factor yet
+— who clicks "Log out" is bounced straight back into the same gate, without
+ever actually being logged out.
+
+What gets them out is an ordinary page elsewhere on the site whose logout
+view isn't behind an MFA gate — and that only works if `MFA_EXEMPT_PATHS`
+contains it, exactly as it already must for the two walls `MfaMiddleware`
+enforces (see the warning in {doc}`settings`). `protect_admin_site()` does
+not consult `MFA_EXEMPT_PATHS` at all — the admin's own gate has no
+exemption mechanism of its own — so this isn't a third set to configure, it's
+the same requirement as always: your project's real logout URL, outside
+`/admin/`, has to stay reachable to a user any wall has trapped.
+:::
+
 ## What is not enforced
 
 - **Unauthenticated requests.** Every wall above only applies once
@@ -198,3 +355,13 @@ leave this at its default.
   challenge before some other sensitive action of your own — say, changing a
   password — apply `mfa_recent_required`/`MfaRecentRequiredMixin` yourself, as shown
   above. See {doc}`security`.
+- **A custom `AdminSite` instance, under `MFA_PROTECT_ADMIN`.**
+  `protect_admin_site()` only patches `django.contrib.admin.site` — the
+  default site. A project that constructs and mounts its **own** `AdminSite`
+  instance instead (rather than registering models onto the default one)
+  gets **no** protection from `MFA_PROTECT_ADMIN` at all: every page on that
+  site is reachable exactly as if the setting were off, with no error or
+  warning to say so. `django_mfa.admin_site.MfaAdminMixin` is the answer for
+  that case — mix it in ahead of `AdminSite` (or your own subclass of it) to
+  get the same `has_permission`/`login` behaviour `protect_admin_site()`
+  applies to the default site. See {doc}`settings`, under `MFA_PROTECT_ADMIN`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -65,6 +65,13 @@ user counts as "protected" (`registry.has_primary_factor()`), whether
 WebAuthn credential, or the recovery-code hashes — for the same reason
 `AuthenticatorAdmin` doesn't (see {doc}`security`).
 
+When `MFA_GRACE_PERIOD` and/or `MFA_REQUIRED_FROM` put this user inside their
+personal grace window (`policy.grace_state()` — see {doc}`settings`), an
+extra `In grace until <date> (<N> days)` line follows `Required: no` — a user
+in grace still reads as not-yet-required, but this makes the window itself
+visible instead of looking indistinguishable from a user the policy never
+covers at all.
+
 ## Unlocking a user: removing every factor
 
     manage.py mfa_reset alice
@@ -108,12 +115,21 @@ their own factor.
     manage.py mfa_report --required-only --format csv > outstanding.csv
 
 With no arguments, prints enrolled-factor counts by type, then "Required but
-unenrolled" — every user `policy.mfa_required_for()` applies to who does not
-hold a primary factor (recovery codes alone don't count; see
-{doc}`enforcement`) and does not hold an active `MfaExemption`. `--required-only`
-skips the per-type counts. `--format csv` switches the outstanding list to
-`pk,<USERNAME_FIELD>` CSV on stdout with nothing else printed ahead of the
-header — pipe it straight into a file. It never prints `Authenticator.data`.
+unenrolled" — every user who does not hold a primary factor (recovery codes
+alone don't count; see {doc}`enforcement`) and does not hold an active
+`MfaExemption`, and either `policy.mfa_required_for()` applies to right now
+**or** is still inside their `policy.grace_state()` window (see
+{doc}`settings`). The second half is deliberate: `mfa_required_for()` returns
+`False` for a user still in grace, so filtering on it alone would silently
+hide exactly the users a rollout report exists to surface. Each such line
+gets an ` -- in grace until <date>` suffix; a user already past due has none.
+`--required-only` skips the per-type counts. `--format csv` switches the
+outstanding list to `pk,<USERNAME_FIELD>,grace_until` CSV on stdout with
+nothing else printed ahead of the header — pipe it straight into a file. The
+`grace_until` column is appended after the existing two, never inserted
+between them, so a consumer indexing by column position is unaffected; it is
+empty for a user who is already due rather than still in grace. It never
+prints `Authenticator.data`.
 
 ## Pruning expired rate-limit counters
 

--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -141,13 +141,18 @@ draw the challenge screen from.
                       "supports_multiple": false}],
       "has_primary_factor": true,
       "recovery_codes_remaining": 10,
-      "stepup_max_age": 300
+      "stepup_max_age": 300,
+      "grace": null
     }
 
 `can_verify_with` and `can_enroll` answer different questions and you need both:
 the first includes recovery codes (a valid way to prove identity), the second is
 what may still be added. `has_primary_factor` is the "is this account actually
 protected" answer, which recovery codes alone do not satisfy.
+
+| Field | Meaning |
+| --- | --- |
+| `grace` | `null`, or `{"required_at": "2026-09-01T00:00:00Z", "days_remaining": N}` when this user would be required to enrol but is not yet. `required_at` is encoded the same way as `created_at` above (`DjangoJSONEncoder`, not `.isoformat()`), so it always carries the trailing `Z` form. Display only — nothing is enforced against `days_remaining`. |
 
 `Authenticator.data` — the TOTP secret, the recovery-code hashes, the WebAuthn
 credential — is never in any response, from any endpoint.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -19,6 +19,9 @@ WebAuthn** — see {doc}`installation_setup`.
 |---|---|---|
 | `MFA_FACTORS` | `["totp", "recovery_codes", "webauthn"]` | Which built-in factor adapters get registered at startup. See [Choosing which factors to offer](#choosing-which-factors-to-offer) below. |
 | `MFA_REQUIRED` | `False` | Who must hold a second factor. `False` (nobody), `True` (every authenticated user), a callable taking a user and returning a bool, or a dotted path to one. A required user with no factor is walled to the security page until they enroll — see {doc}`enforcement`. |
+| `MFA_REQUIRED_FROM` | `None` | A `date` or `datetime` before which nobody is walled by `MFA_REQUIRED`, however it answers. The rollout ramp: set it to your announced cutover and existing users keep working until then. **Does not cover the admin gate** (`MFA_PROTECT_ADMIN`) or `@mfa_required`/`MfaRequiredMixin` views — neither consults grace at all; see {doc}`enforcement`. |
+| `MFA_GRACE_PERIOD` | `None` | `int` days (or a `timedelta`) each user gets from their own anchor before being walled. Covers people who join after the cutover — a user is required from whichever of `MFA_REQUIRED_FROM` and `anchor + MFA_GRACE_PERIOD` is *later*. |
+| `MFA_GRACE_ANCHOR` | `None` | Dotted path or callable, `(user) -> datetime \| None`, giving the per-user start of `MFA_GRACE_PERIOD`. `None` means `user.date_joined`. Return `None` for a user you have no anchor for; they fall back to `MFA_REQUIRED_FROM` alone. Note this runs wherever grace is displayed, so a resolver that queries the database costs a query per render. |
 | `MFA_ISSUER_NAME` | `None` | Issuer label shown next to the username in the user's authenticator app when enrolling TOTP. Set it to your product name; without it the app shows the username alone, which is confusing for anyone with more than one account. |
 | `MFA_EXEMPT_PATHS` | `[]` | URL paths reachable through either of `MfaMiddleware`'s walls: a session pending a second factor, and — when `MFA_REQUIRED` applies — a required user who hasn't enrolled one yet. **Must include your logout URL** — see the warning below. |
 
@@ -257,6 +260,20 @@ explicitly; it does nothing on an install that never did. It answers *identity*
 only — see {doc}`rest_api` for why MFA state still lives in the session, and what
 that means for a client that discards cookies.
 
+## Admin
+
+| Setting | Default | Purpose |
+|---|---|---|
+| `MFA_PROTECT_ADMIN` | `False` | When `True`, no page on `django.contrib.admin`'s default site (`django.contrib.admin.site`) is reachable without a verified session, and `MFA_REQUIRED` additionally applies to `is_staff` users. Enforced by the admin site itself, so it holds even if `MfaMiddleware` is not installed. |
+| `MFA_ADMIN_STEPUP` | `False` | When `True` (and `MFA_PROTECT_ADMIN` is on), admin pages require a challenge within `MFA_STEPUP_MAX_AGE`, not merely a verified session. Set without `MFA_PROTECT_ADMIN` it does nothing, and `django_mfa.E011` says so. |
+
+`MFA_PROTECT_ADMIN` only patches `django.contrib.admin.site` — a project that
+constructs and mounts its **own** `AdminSite` instance instead of the default one
+gets no protection from the setting at all. `django_mfa.admin_site.MfaAdminMixin`
+covers that case: mix it in ahead of `AdminSite` (or your own subclass of it) to get
+the same `has_permission`/`login` behaviour `protect_admin_site()` applies to the
+default site.
+
 ## System checks
 
 django-mfa registers system checks that run on `manage.py check` — and therefore on
@@ -267,7 +284,7 @@ E001–E003 are WebAuthn-only: they return no errors at all unless WebAuthn is
 actually switched on for this install, meaning `MFA_QUICKLOGIN` is on or a WebAuthn
 adapter is registered (true by default). A project with
 `MFA_FACTORS = ["totp", "recovery_codes"]` never trips any of them.
-`E004`–`E009` are not gated the same way — none of them is a WebAuthn setting, so
+`E004`–`E011` are not gated the same way — none of them is a WebAuthn setting, so
 there is nothing to gate on, and they apply to every install regardless of which
 factors are registered.
 
@@ -282,6 +299,8 @@ factors are registered.
 | `django_mfa.E007` | Error | `MFA_VERIFY_RATE_LIMIT`, `MFA_VERIFY_IP_RATE_LIMIT` or `MFA_EMAIL_SEND_RATE_LIMIT` is not a valid `"<count>/<window><unit>"` spec. |
 | `django_mfa.E008` | Error | `MFA_RATE_LIMIT_BACKEND` is not `"database"` or `"cache"`. |
 | `django_mfa.E009` | Error | `MFA_CLIENT_IP_RESOLVER` is a dotted path that fails to import, or resolves to a value that isn't callable. |
+| `django_mfa.E010` | Error | Grace is configured but cannot apply: `MFA_REQUIRED_FROM` is not a date, `MFA_GRACE_PERIOD` is negative or not a number, or `MFA_GRACE_PERIOD` is set with no usable anchor (`MFA_GRACE_ANCHOR` unset and the user model has no `date_joined`). |
+| `django_mfa.E011` | Error | `MFA_ADMIN_STEPUP` is set without `MFA_PROTECT_ADMIN`, so nothing reads it and the admin is unprotected. |
 
 `E003` exists because the failure it prevents is otherwise completely silent.
 Passwordless login logs a user in by calling `django.contrib.auth.login()` with an
@@ -292,7 +311,7 @@ resolves `request.user` to `AnonymousUser` — no exception, no log line, just a
 who was "logged in" a moment ago and is now anonymous again. Catching this at startup
 is far cheaper than a support ticket.
 
-All nine are `Error` rather than `Warning` deliberately, though what each guards
+All eleven are `Error` rather than `Warning` deliberately, though what each guards
 against differs slightly. E001–E003 guard a failure mode that is otherwise silent
 in production (see E003's own explanation below). A misconfigured `MFA_REQUIRED`
 is not silent even without E004 — `policy.resolve()` raises `ImproperlyConfigured`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-mfa"
-version = "4.5.0"
+version = "4.6.0"
 description = "Second-factor authentication for Django: authenticator apps (TOTP), security keys and passkeys (WebAuthn), and recovery codes."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -566,7 +566,7 @@ wheels = [
 
 [[package]]
 name = "django-mfa"
-version = "4.5.0"
+version = "4.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },


### PR DESCRIPTION
- Added support for MFA grace period through `MFA_REQUIRED_FROM` and `MFA_GRACE_PERIOD` settings.
- Introduced `policy.grace_state()` to manage user states during the grace period.
- Updated tests to cover scenarios for users in grace, including security settings and enrollment wall behavior.
- Enhanced documentation to explain the rollout process and admin protection settings.
- Bumped version to 4.6.0 to reflect new features and changes.